### PR TITLE
fix: set paymentConditions at creation; drop dead update-draft-* tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2]
+
+### Changed
+- Advertised MCP server version bumped to **0.1.2** — the tool surface shrank (65 → 59) after
+  removing the non-functional `update-draft-*` tools; the version change also nudges MCP clients to
+  drop the stale tools from a cached tool list.
+
+### Added
+- `paymentConditions` on every `create-draft-*` / `create-finalized-*` document body
+  (`paymentTermLabel` + `paymentTermDuration` in days). The payment term can now be set at
+  creation; previously the field was silently dropped (it was not in the input schema), so
+  invoices fell back to the account default ("Zahlbar sofort, rein netto").
+
+### Removed
+- `update-draft-<type>` for invoices/quotations/credit-notes/order-confirmations/delivery-notes/
+  dunnings. These always failed with **404 Not Found**: the Lexware Office REST API exposes only
+  GET and POST for those document types — there is no PUT/update endpoint (unlike
+  contacts/articles/vouchers, whose update tools remain). A draft document cannot be patched after
+  creation; set all fields at creation via `create-draft-*`, or recreate the draft and delete the
+  old one in the web app.
+
 ## [0.1.1]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lexware-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "license": "MIT",
   "description": "Open-source, self-hostable MCP server for the Lexware Office API",

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,7 +36,7 @@ const client = new LexwareClient({
 const server = new McpServer(
   {
     name: "lexware-office",
-    version: "0.1.1",
+    version: "0.1.2",
   },
   { capabilities: {} },
 );

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -12,9 +12,8 @@ import {
   pageParam,
   quotationInputShape,
   sizeParam,
-  versionParam,
 } from "./schemas.js";
-import { LOCAL_RO, RO, WRITE, deepMergePatch, pagedResult, text } from "./shared.js";
+import { LOCAL_RO, RO, WRITE, pagedResult, text } from "./shared.js";
 
 /** A Lexware voucher-document type and how to create it. */
 interface DocType {
@@ -407,46 +406,13 @@ export function registerDocumentDraftTools(
     );
   }
 
-  // update-draft-<doctype>: edit an existing draft document (read-modify-write).
-  for (const doc of DOC_TYPES) {
-    if (!doc.schema) continue;
-    const updateShape = optionalShape(doc.schema);
-    server.registerTool(
-      {
-        name: `update-draft-${doc.key}`,
-        description:
-          `Update an existing DRAFT ${doc.label} (read-modify-write: the current document is fetched and your ` +
-          `fields are merged over it, so untouched fields like title/introduction aren't wiped). Send only what ` +
-          `you change. If you send lineItems it REPLACES the whole list — include every line. Pass \`version\` for ` +
-          `optimistic locking (omit to use the latest). Only drafts are editable; a finalized document cannot be changed.`,
-        inputSchema: {
-          id: z.string(),
-          version: versionParam(`get-${doc.key}`),
-          ...updateShape,
-        },
-        annotations: WRITE,
-      },
-      async ({ id, version, ...fields }) => {
-        // Read-modify-write: load the current draft and merge the caller's fields over it.
-        const current = await client.get<Record<string, unknown>>(
-          `/v1/${doc.path}/${encodeURIComponent(id)}`,
-        );
-        const body = deepMergePatch(current, {
-          ...fields,
-          version: version ?? (current.version as number),
-        });
-        const updated = await client.request<{ id: string; version: number }>(
-          "PUT",
-          `/v1/${doc.path}/${encodeURIComponent(id)}`,
-          { body, idempotent: false },
-        );
-        return {
-          structuredContent: { ...updated, finalized: false },
-          content: text(`Updated DRAFT ${doc.label} ${id} (now version ${updated.version}).`),
-        };
-      },
-    );
-  }
+  // NOTE: there is deliberately no update-draft-<doctype> tool. The Lexware Office
+  // REST API exposes only GET and POST for invoices/quotations/credit-notes/
+  // order-confirmations/delivery-notes/dunnings — no PUT — so a draft document
+  // cannot be patched after creation (a PUT returns 404). Set every field (incl.
+  // paymentConditions) at creation via create-draft-*; to change a draft, recreate
+  // it and delete the old one in the web app. (Contacts/articles/vouchers DO have
+  // PUT and keep their own update tools.)
 }
 
 /** Finalizing / legally-binding tools for every finalizable document type. Finalize tier. */

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -96,6 +96,20 @@ export const shippingConditionsSchema = z
   })
   .passthrough();
 
+export const paymentConditionsSchema = z
+  .object({
+    paymentTermLabel: z
+      .string()
+      .optional()
+      .describe('Payment-term text on the document, e.g. "Zahlbar innerhalb von 14 Tagen ohne Abzug".'),
+    paymentTermDuration: z
+      .number()
+      .int()
+      .optional()
+      .describe("Days until the invoice is due (drives the Fälligkeitsdatum), e.g. 14. 0 = due immediately."),
+  })
+  .passthrough();
+
 /** Fields common to every voucher document; specific shapes spread this. */
 const baseDocumentShape = {
   voucherDate: z.string().describe("ISO date/dateTime of the document."),
@@ -108,6 +122,12 @@ const baseDocumentShape = {
       .describe("Must include the currency (EUR)."),
   ),
   taxConditions: jsonObj(taxConditionsSchema),
+  paymentConditions: jsonObj(paymentConditionsSchema)
+    .optional()
+    .describe(
+      "Payment terms (paymentTermLabel + paymentTermDuration in days). Set this at creation — the Lexware " +
+        "API has no update endpoint for invoices/quotations/etc., so a draft cannot be patched afterwards.",
+    ),
   title: z.string().optional(),
   introduction: z.string().optional(),
   remark: z.string().optional(),

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -55,17 +55,11 @@ const DRAFT_TOOLS = [
   "create-draft-delivery-note",
   "create-draft-dunning",
   "create-event-subscription",
-  // expansion: bookkeeping vouchers + receipts, file upload, document draft-updates
+  // expansion: bookkeeping vouchers + receipts, file upload
   "create-voucher",
   "update-voucher",
   "upload-voucher-file",
   "upload-file",
-  "update-draft-invoice",
-  "update-draft-quotation",
-  "update-draft-credit-note",
-  "update-draft-order-confirmation",
-  "update-draft-delivery-note",
-  "update-draft-dunning",
 ];
 const FINALIZE_TOOLS = [
   "create-finalized-invoice",

--- a/tests/write-tools.test.ts
+++ b/tests/write-tools.test.ts
@@ -1,9 +1,11 @@
 import type { McpServer } from "skybridge/server";
 import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import type { LexwareClient } from "../src/lexware/client.js";
 import { registerArticleWriteTools } from "../src/tools/articles.js";
 import { registerContactDraftTools } from "../src/tools/contacts.js";
 import { registerDocumentDraftTools, registerDocumentReadTools } from "../src/tools/documents.js";
+import { invoiceInputShape } from "../src/tools/schemas.js";
 import { registerVoucherWriteTools } from "../src/tools/vouchers.js";
 
 type Handler = (input: Record<string, unknown>) => Promise<unknown>;
@@ -153,40 +155,44 @@ describe("update-article (read-modify-write)", () => {
   });
 });
 
-describe("update-draft-<type> (read-modify-write)", () => {
-  it("GETs first, then PUTs the merged invoice, preserving lineItems/address when only title changes", async () => {
-    const current = {
-      id: "i1",
-      organizationId: "org",
-      version: 1,
-      voucherDate: "2026-06-01T00:00:00.000+02:00",
-      address: { contactId: "c1", name: "Acme" },
-      lineItems: [
-        { type: "custom", name: "Item", quantity: 1, unitPrice: { currency: "EUR", netAmount: 100 } },
-      ],
-      totalPrice: { currency: "EUR", totalNetAmount: 100 },
-      taxConditions: { taxType: "net" },
-      title: "Invoice",
-      introduction: "Intro",
-    };
-    const request = vi.fn(async () => ({ id: "i1", version: 2 }));
-    const get = vi.fn(async () => current);
-    const client = { get, request } as unknown as LexwareClient;
+describe("invoice draft: paymentConditions set at creation (the API has no PUT/update for invoices)", () => {
+  const sample = {
+    voucherDate: "2026-06-16T00:00:00.000+02:00",
+    address: { contactId: "c1" },
+    lineItems: [
+      { type: "custom", name: "Item", quantity: 1, unitPrice: { currency: "EUR", netAmount: 100 } },
+    ],
+    totalPrice: { currency: "EUR" },
+    taxConditions: { taxType: "net" },
+    shippingConditions: { shippingType: "service" },
+    paymentConditions: {
+      paymentTermLabel: "Zahlbar innerhalb von 14 Tagen ohne Abzug",
+      paymentTermDuration: 14,
+    },
+  };
 
-    await handlersFor(registerDocumentDraftTools, client)["update-draft-invoice"]({
-      id: "i1",
-      version: 1,
-      title: "Invoice (rev 2)",
+  it("the invoice input schema retains paymentConditions instead of stripping it", () => {
+    const parsed = z.object(invoiceInputShape).parse(sample);
+    expect(parsed.paymentConditions).toEqual({
+      paymentTermLabel: "Zahlbar innerhalb von 14 Tagen ohne Abzug",
+      paymentTermDuration: 14,
     });
+  });
 
-    expect(get).toHaveBeenCalledWith("/v1/invoices/i1");
-    const body = putBody(request);
-    expect(body.lineItems).toEqual(current.lineItems); // preserved
-    expect(body.address).toEqual({ contactId: "c1", name: "Acme" }); // preserved
-    expect(body.taxConditions).toEqual({ taxType: "net" }); // preserved
-    expect(body.introduction).toBe("Intro"); // preserved
-    expect(body.title).toBe("Invoice (rev 2)"); // updated
-    expect(body.version).toBe(1);
+  it("create-draft-invoice forwards paymentConditions in the POST body to /v1/invoices", async () => {
+    const post = vi.fn(async () => ({ id: "i1" }));
+    const client = { post } as unknown as LexwareClient;
+
+    await handlersFor((s, c) => registerDocumentDraftTools(s, c, true), client)["create-draft-invoice"](
+      sample,
+    );
+
+    const call = post.mock.calls[0] as [string, Record<string, unknown>, unknown];
+    expect(call[0]).toBe("/v1/invoices");
+    expect(call[1].paymentConditions).toEqual({
+      paymentTermLabel: "Zahlbar innerhalb von 14 Tagen ohne Abzug",
+      paymentTermDuration: 14,
+    });
   });
 });
 


### PR DESCRIPTION
## Why
Two issues surfaced while preparing invoices via the live connector:

1. **`update-draft-*` always returned 404.** The Lexware Office REST API exposes only **GET and POST** for invoices/quotations/credit-notes/order-confirmations/delivery-notes/dunnings — there is **no PUT/update endpoint** (unlike contacts/articles/vouchers). The read-modify-write GET succeeded, the PUT 404'd (route absent). So all six `update-draft-*` tools could never work.
2. **`paymentConditions` was silently dropped.** It wasn't in the document input schema, so Zod stripped it before the POST → invoices fell back to the account default ("Zahlbar sofort, rein netto").

## Changes
- Add `paymentConditions` (`paymentTermLabel` + `paymentTermDuration`) to the shared base document shape → payment term settable at creation (removes the main reason to "update").
- Remove the six non-functional `update-draft-*` tools (+ now-unused imports), with an explanatory comment.
- Tests: schema + POST-body coverage for `paymentConditions`; drop the dead update-draft tests; trim the registration-list test.
- Bump advertised version 0.1.1 → 0.1.2 (tools 65 → 59) so clients refresh the cached tool list.

## Verification
- `npm run typecheck` ✅
- `npm test` ✅ (96 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)