### PR TITLE
feat: add summarize-vouchers (server-side voucherlist aggregation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3]
+
+### Added
+- `summarize-vouchers` (read tier) — server-side aggregation over the voucherlist for a date range:
+  paginates all matches and returns counts plus summed **gross** (`totalAmount`) and **open**
+  (`openAmount`) amounts, grouped by `voucherType` / `voucherStatus` / `month` / `contact` / `currency` /
+  `none`. Avoids blowing the token limit on large ranges (no per-row dump). The net/VAT split is not in the
+  voucherlist, so this reports gross only. A `maxPages` cap (default 40 × 250) flags `truncated` if hit.
+
+### Changed
+- Advertised MCP server version bumped to **0.1.3** so clients pick up the new `summarize-vouchers` tool.
+
 ## [0.1.2]
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lexware-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "license": "MIT",
   "description": "Open-source, self-hostable MCP server for the Lexware Office API",

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,7 +36,7 @@ const client = new LexwareClient({
 const server = new McpServer(
   {
     name: "lexware-office",
-    version: "0.1.2",
+    version: "0.1.3",
   },
   { capabilities: {} },
 );

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -87,6 +87,27 @@ const VOUCHERTYPE_TO_PATH: Record<string, string> = {
   voucher: "vouchers",
 };
 
+/** Dimensions `summarize-vouchers` can group totals by. */
+const SUMMARY_GROUP_BY = ["voucherType", "voucherStatus", "month", "contact", "currency", "none"] as const;
+
+/** Bucket key for a voucherlist row under the chosen grouping dimension. */
+function summaryGroupKey(row: VoucherlistEntry, groupBy: (typeof SUMMARY_GROUP_BY)[number]): string {
+  switch (groupBy) {
+    case "voucherStatus":
+      return row.voucherStatus || "(unknown)";
+    case "month":
+      return row.voucherDate ? row.voucherDate.slice(0, 7) : "(no date)"; // YYYY-MM
+    case "contact":
+      return row.contactName || "(no contact)";
+    case "currency":
+      return row.currency || "(no currency)";
+    case "none":
+      return "all";
+    default:
+      return row.voucherType || "(unknown)";
+  }
+}
+
 /** Read tools for financial documents. Always registered. */
 export function registerDocumentReadTools(
   server: McpServer,
@@ -122,6 +143,132 @@ export function registerDocumentReadTools(
         size,
       });
       return pagedResult(result, "voucher(s)");
+    },
+  );
+
+  server.registerTool(
+    {
+      name: "summarize-vouchers",
+      description:
+        "Aggregate the voucherlist over a date range WITHOUT returning every row: server-side paginates all " +
+        "matches and returns counts plus summed gross/open amounts, grouped by a chosen dimension. Use this " +
+        "for totals (e.g. 'gross sales invoices in Q2') instead of get-voucherlist, which can blow the token " +
+        "limit on large ranges. Amounts are GROSS (the voucherlist's totalAmount/openAmount) in the document " +
+        "currency — the net/VAT split is not in the voucherlist, so this does not break out USt. " +
+        "voucherType/voucherStatus default to 'any'.",
+      inputSchema: {
+        voucherType: z.enum(VOUCHER_TYPES).default("any"),
+        voucherStatus: z.enum(VOUCHER_STATUSES).default("any"),
+        contactId: z.string().optional(),
+        voucherDateFrom: z.string().optional().describe("ISO date lower bound."),
+        voucherDateTo: z.string().optional().describe("ISO date upper bound."),
+        archived: jsonBool(z.boolean().optional()),
+        groupBy: z
+          .enum(SUMMARY_GROUP_BY)
+          .default("voucherType")
+          .describe("Dimension to group totals by. 'month' buckets by voucherDate (YYYY-MM); 'none' = one total."),
+        maxPages: jsonNum(z.number().int().min(1).max(200).default(40)).describe(
+          "Safety cap on pages scanned (250 rows/page). If hit, the result is flagged truncated.",
+        ),
+      },
+      annotations: RO,
+    },
+    async ({
+      voucherType,
+      voucherStatus,
+      contactId,
+      voucherDateFrom,
+      voucherDateTo,
+      archived,
+      groupBy,
+      maxPages,
+    }) => {
+      const SIZE = 250;
+      const groups = new Map<
+        string,
+        { count: number; sumTotalAmount: number; sumOpenAmount: number; currencies: Set<string> }
+      >();
+      let scanned = 0;
+      let totalElements = 0;
+      let page = 0;
+      let truncated = false;
+      // Walk every page; we only keep aggregates, so the response size is bounded
+      // regardless of how many vouchers match.
+      for (;;) {
+        const res = await client.get<Paged<VoucherlistEntry>>("/v1/voucherlist", {
+          voucherType,
+          voucherStatus,
+          contactId,
+          voucherDateFrom,
+          voucherDateTo,
+          archived,
+          page,
+          size: SIZE,
+        });
+        totalElements = res.totalElements;
+        for (const row of res.content) {
+          scanned++;
+          const key = summaryGroupKey(row, groupBy);
+          const g = groups.get(key) ?? {
+            count: 0,
+            sumTotalAmount: 0,
+            sumOpenAmount: 0,
+            currencies: new Set<string>(),
+          };
+          g.count++;
+          g.sumTotalAmount += row.totalAmount ?? 0;
+          g.sumOpenAmount += row.openAmount ?? 0;
+          if (row.currency) g.currencies.add(row.currency);
+          groups.set(key, g);
+        }
+        if (res.last) break;
+        page++;
+        if (page >= maxPages) {
+          truncated = true;
+          break;
+        }
+      }
+      const round2 = (n: number) => Math.round(n * 100) / 100;
+      const currencyOf = (set: Set<string>) =>
+        set.size === 1 ? [...set][0] : set.size === 0 ? undefined : "mixed";
+      const groupList = [...groups.entries()]
+        .map(([key, g]) => ({
+          key,
+          count: g.count,
+          sumTotalAmount: round2(g.sumTotalAmount),
+          sumOpenAmount: round2(g.sumOpenAmount),
+          currency: currencyOf(g.currencies),
+        }))
+        .sort((a, b) => b.sumTotalAmount - a.sumTotalAmount);
+      const allCurrencies = new Set<string>(
+        [...groups.values()].flatMap((g) => [...g.currencies]),
+      );
+      const currency = currencyOf(allCurrencies);
+      const grandTotal = round2(groupList.reduce((s, g) => s + g.sumTotalAmount, 0));
+      const grandOpen = round2(groupList.reduce((s, g) => s + g.sumOpenAmount, 0));
+      return {
+        structuredContent: {
+          filters: {
+            voucherType,
+            voucherStatus,
+            contactId,
+            voucherDateFrom,
+            voucherDateTo,
+            archived,
+            groupBy,
+          },
+          scanned,
+          totalElements,
+          pagesScanned: page + 1,
+          truncated,
+          grandTotal: { sumTotalAmount: grandTotal, sumOpenAmount: grandOpen, currency },
+          groups: groupList,
+        },
+        content: text(
+          `Summarized ${scanned} voucher(s)${truncated ? ` (TRUNCATED at ${maxPages} pages × ${SIZE})` : ""}; ` +
+            `gross total ${currency ?? ""} ${grandTotal} across ${groupList.length} ${groupBy} group(s).`,
+        ),
+      };
     },
   );
 

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -11,6 +11,7 @@ const READ_TOOLS = [
   "list-articles",
   "get-article",
   "get-voucherlist",
+  "summarize-vouchers",
   "get-invoice",
   "get-quotation",
   "get-credit-note",

--- a/tests/write-tools.test.ts
+++ b/tests/write-tools.test.ts
@@ -352,3 +352,57 @@ describe("render-*-pdf and get-document-file download /file", () => {
     expect(client.getBinary).toHaveBeenCalledWith("/v1/credit-notes/c3/file");
   });
 });
+
+describe("summarize-vouchers (server-side aggregation, no row dump)", () => {
+  const sumHandler = (get: ReturnType<typeof vi.fn>) =>
+    handlersFor(
+      (s, c) => registerDocumentReadTools(s, c, "https://app.test"),
+      { get } as unknown as LexwareClient,
+    )["summarize-vouchers"];
+
+  it("walks every page and sums gross/open grouped by voucherType (sorted desc)", async () => {
+    const pages: Record<number, unknown> = {
+      0: {
+        content: [
+          { id: "1", voucherType: "salesinvoice", voucherStatus: "open", voucherDate: "2026-04-01", totalAmount: 100, openAmount: 100, currency: "EUR" },
+          { id: "2", voucherType: "salesinvoice", voucherStatus: "paid", voucherDate: "2026-05-01", totalAmount: 200, openAmount: 0, currency: "EUR" },
+        ],
+        first: true, last: false, number: 0, numberOfElements: 2, size: 250, totalPages: 2, totalElements: 3,
+      },
+      1: {
+        content: [
+          { id: "3", voucherType: "purchaseinvoice", voucherStatus: "paid", voucherDate: "2026-05-15", totalAmount: 50, openAmount: 0, currency: "EUR" },
+        ],
+        first: false, last: true, number: 1, numberOfElements: 1, size: 250, totalPages: 2, totalElements: 3,
+      },
+    };
+    const get = vi.fn(async (_p: string, q: { page: number }) => pages[q.page]);
+    const res = (await sumHandler(get)({
+      voucherType: "any", voucherStatus: "any", groupBy: "voucherType", maxPages: 40,
+    })) as { structuredContent: Record<string, any> };
+    const sc = res.structuredContent;
+
+    expect(get).toHaveBeenCalledTimes(2); // both pages walked
+    expect(sc.scanned).toBe(3);
+    expect(sc.truncated).toBe(false);
+    expect(sc.grandTotal).toEqual({ sumTotalAmount: 350, sumOpenAmount: 100, currency: "EUR" });
+    const byType = Object.fromEntries(sc.groups.map((g: any) => [g.key, g]));
+    expect(byType.salesinvoice).toEqual({ key: "salesinvoice", count: 2, sumTotalAmount: 300, sumOpenAmount: 100, currency: "EUR" });
+    expect(byType.purchaseinvoice.sumTotalAmount).toBe(50);
+    expect(sc.groups[0].key).toBe("salesinvoice"); // sorted by gross desc
+  });
+
+  it("flags truncated when maxPages is hit before the last page", async () => {
+    const page = {
+      content: [{ id: "1", voucherType: "salesinvoice", voucherStatus: "open", totalAmount: 10, openAmount: 10, currency: "EUR" }],
+      first: true, last: false, number: 0, numberOfElements: 1, size: 250, totalPages: 5, totalElements: 5,
+    };
+    const get = vi.fn(async () => page);
+    const res = (await sumHandler(get)({ groupBy: "none", maxPages: 1 })) as {
+      structuredContent: Record<string, any>;
+    };
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(res.structuredContent.truncated).toBe(true);
+    expect(res.structuredContent.groups[0].key).toBe("all");
+  });
+});


### PR DESCRIPTION
## Why
`get-voucherlist` can blow the MCP token limit on large date ranges, so totals (e.g. "gross sales invoices in Q2") currently mean dumping every row and aggregating by hand. Idea adapted from JannikWempe/mcp-lexware-office's finance helpers — but kept as a curated, typed, **read-only** tool (no sandbox / code-mode), in line with this server's permission model.

## What
New `summarize-vouchers` (read tier): server-side paginates the full voucherlist for a filter/date range and returns **aggregates only** — counts plus summed **gross** (`totalAmount`) and **open** (`openAmount`) amounts, grouped by `voucherType` / `voucherStatus` / `month` / `contact` / `currency` / `none`. Bounded response regardless of match count. `maxPages` cap (default 40 × 250) flags `truncated`.

Gross only — the net/VAT split isn't in the voucherlist (documented in the tool description).

## Notes
- Contains **no** tenant/PII data — pure aggregation over the runtime account (single-tenant, bring-your-own-key). PII grep over the repo is clean.
- Bump advertised version 0.1.2 → 0.1.3 so clients pick up the new tool.

## Verification
- `npm run typecheck` ✅
- `npm test` ✅ (98 passed — 2 new for aggregation + truncation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)