### PR TITLE
Security & correctness hardening from code review (v0.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,98 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6]
+
+### Fixed
+- **Removed the non-functional `archived` param from create-contact / update-contact.** `archived` is
+  **read-only** on the Lexware contacts API (confirmed against the docs and live: a `PUT` with
+  `archived:true` is accepted and bumps the version but leaves the contact active). The param silently did
+  nothing and misled the model into thinking it could archive/hide contacts. Archiving a contact is a
+  web-app-only action; there is no contact delete via the API.
+
+## [0.1.5]
+
+Hardening pass from a code review of 0.1.4.
+
+### Fixed
+- **Error-body reads are now classified too.** A failure while reading a non-2xx response body
+  (connection reset / timeout mid-stream) previously threw a raw `TypeError`; it now yields a
+  `LexwareApiError` carrying the real HTTP status, so a 404 stays a 404 and idempotent-delete handling
+  keeps working.
+- **`create-draft-*` fails loudly on a stale `finalize=true`.** After finalization moved to the
+  dedicated `create-finalized-*` tools, a client still sending `finalize:true` had it silently stripped
+  and got a draft + success. The draft tools now reject `finalize`/`confirm_finalize` with a clear
+  pointer to `create-finalized-*`.
+- **One-off voucher `contactName`** now also sets `useCollectiveContact:true` (lexoffice pairs a custom
+  contact name with the collective contact), so switching a referenced voucher to a one-off name doesn't 406.
+- **Base64 validation** no longer rejects non-canonical (but universally decodable) padding, and validates
+  via a charset+length check instead of re-encoding the whole payload (cheaper for multi-MB uploads).
+- **Delete tools** return an `alreadyAbsent` flag so callers can tell "deleted it" from "it never existed".
+
+### Changed
+- **The raised upload body limit no longer widens the pre-auth surface.** The 12 MB JSON parser is mounted
+  on `/mcp` *after* the auth gate; other routes keep the ~100 KB default. An unauthenticated request can no
+  longer force a multi-MB parse. The limit is applied via an in-place handler swap (robust to Express
+  internals), and if it can't be applied the server now logs a loud WARNING instead of a quiet token.
+- **Webhook event subscriptions moved to the finalize tier** (create + delete, gated together, off by
+  default): a webhook streams financial events to an arbitrary external URL, so it's now opt-in rather than
+  available by default.
+- **`additionalFields` is now on every create tool** (contacts, articles, vouchers, documents), not just
+  documents, closing the same silent top-level-strip data loss everywhere. Reserved control keys
+  (`finalize`, `version`, `id`, …) are stripped from it so they can't be smuggled into a request body.
+- Finalize force-enabling drafts, and a failure to raise the body limit, now emit explicit startup WARNINGs.
+
+## [0.1.4]
+
+### Fixed
+- **Large file uploads no longer fail.** `upload-file` / `upload-voucher-file` bodies over ~75 KB were
+  rejected before reaching the tool, because Skybridge pre-applies `express.json()` at body-parser's
+  ~100 KB default. The JSON body limit is now raised to 12 MB, so multi-MB receipts upload as documented.
+- **`get-document`** dispatches `voucherType: "recurringtemplate"` (a value the voucherlist returns) to
+  `/v1/recurring-templates/{id}` instead of throwing "Unknown voucherType".
+- **`update-voucher`**: passing a one-off `contactName` now clears the `contactId` carried over from the
+  current voucher (they can't coexist — lexoffice 406 `custom_contact_name_for_referenced_contact_not_allowed`).
+  Its `version` param now also accepts a string-serialized number, like the other update tools.
+- **Base64 uploads are validated** — a malformed payload (e.g. a leftover `data:…;base64,` prefix) is
+  rejected with a clear error instead of silently uploading corrupt bytes.
+- **`confirm_finalize`** accepts the string `"true"` from clients that serialize booleans as strings
+  (finalization was previously unreachable for them).
+- **`summarize-vouchers`** reports the correct `pagesScanned` when the `maxPages` cap is hit (was off by one).
+- **HTTP client**: a failure while reading a response body (timeout/reset mid-stream) is mapped to a
+  classified `LexwareApiError` instead of leaking a raw `DOMException`/`TypeError`; abandoned response
+  bodies are drained before a retry so keep-alive sockets are reused; a long plain-text error body is
+  truncated (not dropped); the HTTP-date `Retry-After` path uses the injectable clock.
+- **Idempotent deletes**: `delete-article` / `delete-event-subscription` treat a 404 as already-gone
+  instead of reporting a false failure when a retried delete's first attempt already succeeded.
+- Empty list results render `page 1/1` instead of the impossible `page 1/0`.
+- Static-bearer `401` responses include a `WWW-Authenticate` challenge (RFC 9110).
+
+### Changed
+- **Finalization is now only via the dedicated `create-finalized-*` tools.** The `finalize` /
+  `confirm_finalize` flags were removed from `create-draft-*` (a legally-binding write must never be a flag
+  on a draft tool). One-step issuing still works — call `create-finalized-<type>` (finalize tier).
+- **Enabling the finalize tier now also enables drafts**, so a deployment can never expose only the
+  irreversible `create-finalized-*` tools with no safe draft path.
+- **`delete-event-subscription` moved to the drafts tier**, symmetric with `create-event-subscription`:
+  unsubscribing just stops a webhook and is trivially recreatable.
+- OAuth authorization/token/registration endpoints in the AS metadata are now **overridable**
+  (`OAUTH_AUTHORIZATION_ENDPOINT`, `OAUTH_TOKEN_ENDPOINT`, `OAUTH_REGISTRATION_ENDPOINT`); WorkOS-layout
+  defaults are unchanged, so non-WorkOS issuers (Auth0, Keycloak) can advertise correct endpoints.
+- An OAuth request from a disallowed email domain returns **403** (valid token, not authorized) instead of
+  401, which made some clients loop re-authenticating.
+- Advertised MCP server version bumped to **0.1.4**.
+
+### Added
+- **`additionalFields`** escape hatch on document create tools: valid Lexware body fields not modeled by the
+  schema (e.g. `xRechnung`) can be passed and are merged into the request, rather than being silently
+  stripped by the SDK's strip-mode top-level object.
+- Startup warning when `/mcp` is unauthenticated.
+
+### Security
+- `create-event-subscription` requires an `https://` `callbackUrl` (matches Lexware's Grade-A HTTPS
+  requirement), and `delete-event-subscription` is available whenever create is — so a webhook opened by,
+  e.g., prompt-injected content can always be removed.
+
 ## [0.1.3]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Related projects — local (stdio) Lexware MCP servers:
 
 ## Capabilities
 
-65 tools across three tiers you enable via environment variables:
+60 tools across three tiers you enable via environment variables:
 
 | Tier | Default | What it covers |
 |------|---------|----------------|
-| **Read** | always on | Profile; contacts & articles (list/get); the voucherlist; full documents (invoices, quotations, credit notes, order confirmations, delivery notes, dunnings, down-payment invoices, vouchers); **render any document type to PDF** and **download files/receipts** (returned inline as embedded resources); batch & type-dispatched reads (get-vouchers, get-document, get-voucher-file, get-document-file); payments; reference data (countries, payment conditions, posting categories, print layouts); recurring templates (get & list); event subscriptions; document deeplinks |
-| **Drafts/writes** (`LEXWARE_ENABLE_DRAFTS`) | on | Create **and update draft** invoices/quotations/credit-notes/order-confirmations/delivery-notes/dunnings; create & update contacts, articles, and **bookkeeping vouchers**; **upload files** and **attach receipts** to vouchers; create event subscriptions; optionally issue documents **finalized** (`finalize=true`, requires `LEXWARE_ENABLE_FINALIZE`) or as **follow-ups** (`precedingSalesVoucherId`) |
-| **Finalize** (`LEXWARE_ENABLE_FINALIZE`) | off | Issue **legally binding** finalized documents (confirmation-gated); irreversible deletes (articles, event subscriptions) |
+| **Read** | always on | Profile; contacts & articles (list/get); the voucherlist (plus `summarize-vouchers` for server-side totals); full documents (invoices, quotations, credit notes, order confirmations, delivery notes, dunnings, down-payment invoices, vouchers); **render any document type to PDF** and **download files/receipts** (returned inline as embedded resources); batch & type-dispatched reads (get-vouchers, get-document, get-voucher-file, get-document-file); payments; reference data (countries, payment conditions, posting categories, print layouts); recurring templates (get & list); event subscriptions; document deeplinks |
+| **Drafts/writes** (`LEXWARE_ENABLE_DRAFTS`) | on | Create **draft** invoices/quotations/credit-notes/order-confirmations/delivery-notes/dunnings (the Lexware API has no update endpoint for these — set every field, including payment terms, at creation); create & update contacts, articles, and **bookkeeping vouchers**; **upload files** and **attach receipts** to vouchers; create documents as **follow-ups** (`precedingSalesVoucherId`) |
+| **Finalize** (`LEXWARE_ENABLE_FINALIZE`) | off | Issue **legally binding** finalized documents in one step via the dedicated `create-finalized-*` tools (confirmation-gated); irreversible article deletes; **manage webhook event subscriptions** (create + delete — a webhook streams financial events to an external URL, so it's opt-in). Enabling this tier also enables Drafts. |
 
 Set `LEXWARE_READ_ONLY=true` to force read-only (overrides the flags above).
 
@@ -97,11 +97,13 @@ LEXWARE_API_KEY=... MCP_AUTH_TOKEN=... npm start
 | `OAUTH_RESOURCE` / `SERVER_URL` | — | This server's public URL (token audience / Resource Indicator). Required in OAuth mode |
 | `OAUTH_ALLOWED_EMAIL_DOMAINS` | — | Comma-separated allow-list of email domains (e.g. `example.com`) |
 | `OAUTH_VERIFY_AUDIENCE` | `true` | Verify the token `aud` matches `OAUTH_RESOURCE`. **Keep `true`.** Setting `false` accepts *any* valid token from the issuer — including one minted for a different app on the same issuer (a confused-deputy risk). Only disable for a dedicated, single-audience issuer that has no Resource Indicator |
+| `OAUTH_JWKS_URL` / `OAUTH_USERINFO_URL` | derived from issuer | Override the JWKS / OIDC userinfo endpoints (defaults use the WorkOS-AuthKit layout) |
+| `OAUTH_AUTHORIZATION_ENDPOINT` / `OAUTH_TOKEN_ENDPOINT` / `OAUTH_REGISTRATION_ENDPOINT` | derived from issuer | Override the endpoints advertised in the authorization-server metadata. Defaults use the WorkOS layout (`{issuer}/oauth2/*`); set these for other IdPs (e.g. Auth0: `/authorize`, `/oauth/token`) |
 | `MCP_AUTH_TOKEN` | — (**required**¹) | Static bearer token clients send to reach `/mcp` (used when OAuth is off) |
-| `MCP_ALLOW_UNAUTHENTICATED` | `false` | Opt out of auth (trusted local use only) |
+| `MCP_ALLOW_UNAUTHENTICATED` | `false` | Opt out of auth (trusted local use only — bind to localhost/private network) |
 | `LEXWARE_READ_ONLY` | `false` | Register only read tools (hard override) |
 | `LEXWARE_ENABLE_DRAFTS` | `true` | Enable create-draft tools |
-| `LEXWARE_ENABLE_FINALIZE` | `false` | Enable finalize / legally-binding tools |
+| `LEXWARE_ENABLE_FINALIZE` | `false` | Enable finalize / legally-binding tools (also enables Drafts) |
 | `LEXWARE_API_BASE_URL` | `https://api.lexware.io` | API base URL |
 | `LEXWARE_APP_BASE_URL` | `https://app.lexware.de` | Web-app base for document deeplinks |
 | `PORT` | `8080` | Listen port (your platform may inject this) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lexware-mcp",
-  "version": "0.1.1",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexware-mcp",
-      "version": "0.1.1",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -346,9 +346,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -362,9 +362,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -394,9 +394,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -426,9 +426,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -442,9 +442,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -458,9 +458,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -474,9 +474,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -490,9 +490,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -538,9 +538,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -570,9 +570,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -618,9 +618,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -634,9 +634,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -650,9 +650,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -682,9 +682,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -698,9 +698,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -714,9 +714,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -2321,9 +2321,9 @@
       ]
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2334,32 +2334,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -2780,9 +2780,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lexware-mcp",
-  "version": "0.1.3",
+  "version": "0.1.6",
   "private": false,
   "license": "MIT",
   "description": "Open-source, self-hostable MCP server for the Lexware Office API",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -18,6 +18,9 @@ export function bearerAuthMiddleware(token: string): RequestHandler {
     const ok =
       providedBuf.length === expected.length && timingSafeEqual(providedBuf, expected);
     if (!ok) {
+      // RFC 9110 §11.6.1: a 401 MUST carry a WWW-Authenticate challenge so clients
+      // know a bearer token is expected (mirrors the OAuth path's behaviour).
+      res.set("WWW-Authenticate", 'Bearer error="invalid_token"');
       res.status(401).json({ error: "unauthorized" });
       return;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,12 @@ export type AuthConfig =
       allowedEmailDomains: string[];
       /** OIDC userinfo endpoint, used to fetch email when it isn't a token claim. */
       userinfoUrl: string;
+      /** Authorization endpoint advertised in AS metadata (overridable for non-WorkOS IdPs). */
+      authorizationEndpoint: string;
+      /** Token endpoint advertised in AS metadata (overridable for non-WorkOS IdPs). */
+      tokenEndpoint: string;
+      /** Dynamic client registration endpoint advertised in AS metadata. */
+      registrationEndpoint: string;
     }
   | { mode: "static"; token: string }
   | { mode: "none" };
@@ -60,6 +66,8 @@ export interface Config {
   port: number;
   debugLogging: boolean;
   capabilities: Capabilities;
+  /** Non-fatal configuration notices to log at startup (e.g. a flag that was overridden). */
+  warnings: string[];
 }
 
 const DEFAULT_BASE_URL = "https://api.lexware.io";
@@ -163,7 +171,36 @@ function resolveAuth(env: NodeJS.ProcessEnv): AuthConfig {
     );
     const jwksUrl = normalizeUrl(env.OAUTH_JWKS_URL, `${issuerBase}/oauth2/jwks`, "OAUTH_JWKS_URL");
     const verifyAudience = parseBool(env.OAUTH_VERIFY_AUDIENCE, true);
-    return { mode: "oauth", issuer, jwksUrl, resource, verifyAudience, allowedEmailDomains, userinfoUrl };
+    // Endpoints default to the WorkOS-AuthKit layout but are overridable so other
+    // IdPs (Auth0: /authorize + /oauth/token; Keycloak; Clerk) advertise correctly
+    // in the /.well-known/oauth-authorization-server metadata.
+    const authorizationEndpoint = normalizeUrl(
+      env.OAUTH_AUTHORIZATION_ENDPOINT,
+      `${issuerBase}/oauth2/authorize`,
+      "OAUTH_AUTHORIZATION_ENDPOINT",
+    );
+    const tokenEndpoint = normalizeUrl(
+      env.OAUTH_TOKEN_ENDPOINT,
+      `${issuerBase}/oauth2/token`,
+      "OAUTH_TOKEN_ENDPOINT",
+    );
+    const registrationEndpoint = normalizeUrl(
+      env.OAUTH_REGISTRATION_ENDPOINT,
+      `${issuerBase}/oauth2/register`,
+      "OAUTH_REGISTRATION_ENDPOINT",
+    );
+    return {
+      mode: "oauth",
+      issuer,
+      jwksUrl,
+      resource,
+      verifyAudience,
+      allowedEmailDomains,
+      userinfoUrl,
+      authorizationEndpoint,
+      tokenEndpoint,
+      registrationEndpoint,
+    };
   }
 
   // 2) Static bearer token.
@@ -205,8 +242,20 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
 
   const readOnly = parseBool(env.LEXWARE_READ_ONLY, false);
   // READ_ONLY is a hard override: it wins over the individual enable flags.
-  const enableDrafts = readOnly ? false : parseBool(env.LEXWARE_ENABLE_DRAFTS, true);
   const enableFinalize = readOnly ? false : parseBool(env.LEXWARE_ENABLE_FINALIZE, false);
+  // Finalize implies drafts: the finalize tier issues legally-binding versions of
+  // draft documents, so enabling it without drafts would expose ONLY the
+  // irreversible create-finalized-* tools (no safe draft path). Never allow that.
+  const draftsRequested = parseBool(env.LEXWARE_ENABLE_DRAFTS, true);
+  const enableDrafts = readOnly ? false : draftsRequested || enableFinalize;
+
+  const warnings: string[] = [];
+  if (!readOnly && !draftsRequested && enableFinalize) {
+    warnings.push(
+      "LEXWARE_ENABLE_DRAFTS=false was overridden to true because LEXWARE_ENABLE_FINALIZE=true — the " +
+        "finalize tier issues binding versions of draft documents and cannot run without the drafts tier.",
+    );
+  }
 
   return {
     lexwareApiKey,
@@ -220,6 +269,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     port: parsePort(env.PORT),
     debugLogging: parseBool(env.LEXWARE_DEBUG_LOGGING, false),
     capabilities: { read: true, drafts: enableDrafts, finalize: enableFinalize },
+    warnings,
   };
 }
 

--- a/src/lexware/client.ts
+++ b/src/lexware/client.ts
@@ -43,6 +43,7 @@ export class LexwareClient {
   private readonly debug: boolean;
   private readonly fetchFn: typeof fetch;
   private readonly sleep: (ms: number) => Promise<void>;
+  private readonly now: () => number;
   private readonly random: () => number;
   private readonly maxRetries: number;
   private readonly requestTimeoutMs: number;
@@ -54,6 +55,7 @@ export class LexwareClient {
     this.debug = opts.debug ?? false;
     this.fetchFn = opts.fetchFn ?? fetch;
     this.sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    this.now = opts.now ?? Date.now;
     this.random = opts.random ?? Math.random;
     this.maxRetries = opts.maxRetries ?? 4;
     this.requestTimeoutMs = opts.requestTimeoutMs ?? 30_000;
@@ -86,7 +88,11 @@ export class LexwareClient {
       body: bodyText,
       idempotent: opts.idempotent,
     });
-    return (await this.safeParse(res)) as T;
+    try {
+      return (await this.safeParse(res)) as T;
+    } catch (err) {
+      throw this.bodyReadError(method, path, err);
+    }
   }
 
   /**
@@ -102,8 +108,12 @@ export class LexwareClient {
       headers: { Authorization: `Bearer ${this.apiKey}`, Accept: accept },
       idempotent: true,
     });
-    const data = Buffer.from(await res.arrayBuffer());
-    return { data, contentType: res.headers.get("content-type") ?? accept };
+    try {
+      const data = Buffer.from(await res.arrayBuffer());
+      return { data, contentType: res.headers.get("content-type") ?? accept };
+    } catch (err) {
+      throw this.bodyReadError("GET", path, err);
+    }
   }
 
   /**
@@ -186,18 +196,29 @@ export class LexwareClient {
 
       // 429 is always safe to retry: a throttled call is not executed.
       if (res.status === 429 && attempt < this.maxRetries) {
-        await this.sleep(this.retryAfterMs(res, attempt));
+        const waitMs = this.retryAfterMs(res, attempt);
+        await this.drain(res); // release the keep-alive connection before retrying
+        await this.sleep(waitMs);
         attempt++;
         continue;
       }
       // Transient upstream errors: retry only idempotent calls.
       if (RETRYABLE_STATUS.has(res.status) && opts.idempotent && attempt < this.maxRetries) {
+        await this.drain(res); // release the keep-alive connection before retrying
         await this.backoff(attempt++);
         continue;
       }
 
       if (!res.ok) {
-        const body = await this.safeParse(res);
+        // Read the error body defensively: if the body stream fails mid-read we still
+        // throw a LexwareApiError carrying the real status (so e.g. a 404 stays a 404
+        // and isNotFound() keeps working), just without the parsed detail.
+        let body: unknown;
+        try {
+          body = await this.safeParse(res);
+        } catch {
+          body = undefined;
+        }
         throw new LexwareApiError(res.status, describeErrorBody(res.status, res.statusText, body), body);
       }
 
@@ -213,6 +234,24 @@ export class LexwareClient {
       }
     }
     return url.toString();
+  }
+
+  /** Discard an abandoned response body so undici can reuse the keep-alive socket. */
+  private async drain(res: Response): Promise<void> {
+    try {
+      await res.body?.cancel();
+    } catch {
+      // Best-effort: a body already errored/closed is fine to ignore.
+    }
+  }
+
+  /** Map a failure while reading a response body to a classified network error. */
+  private bodyReadError(method: string, path: string, err: unknown): LexwareApiError {
+    this.log(method, path, "body-read-error");
+    return new LexwareApiError(
+      0,
+      `Network error reading Lexware response: ${err instanceof Error ? err.message : "unknown"}`,
+    );
   }
 
   /** Parse a response body as JSON when possible, otherwise return text/undefined. */
@@ -240,7 +279,7 @@ export class LexwareClient {
         ms = Number(trimmed) * 1000;
       } else {
         const date = Date.parse(trimmed);
-        if (!Number.isNaN(date)) ms = date - Date.now();
+        if (!Number.isNaN(date)) ms = date - this.now();
       }
       if (ms !== undefined) {
         // Clamp: never hammer (floor) and never hang for minutes/hours (ceiling).

--- a/src/lexware/errors.ts
+++ b/src/lexware/errors.ts
@@ -29,8 +29,20 @@ export class LexwareApiError extends Error {
   }
 }
 
+/** True for a {@link LexwareApiError} representing a 404 Not Found. */
+export function isNotFound(err: unknown): boolean {
+  return err instanceof LexwareApiError && err.kind === "not_found";
+}
+
 /** Max IssueList entries rendered into a message before we summarize the remainder. */
 const MAX_ISSUES = 25;
+/** Max characters of a raw error body rendered into a message (truncate, never drop). */
+const MAX_BODY_CHARS = 2000;
+
+/** Clamp a string to at most `max` chars, appending an ellipsis when truncated. */
+function clampText(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max)}…`;
+}
 
 /**
  * Build a safe, helpful message from a Lexware error response body.
@@ -58,8 +70,10 @@ export function describeErrorBody(status: number, statusText: string, body: unkn
       if (detail) parts.push(detail);
     }
     if (issues.length > MAX_ISSUES) parts.push(`…and ${issues.length - MAX_ISSUES} more`);
-  } else if (typeof body === "string" && body.trim() && body.length < 2000) {
-    parts.push(body.trim());
+  } else if (typeof body === "string" && body.trim()) {
+    // Truncate a long plain-text body (e.g. an HTML 5xx page) rather than dropping
+    // it — otherwise all upstream diagnostic detail would be lost.
+    parts.push(clampText(body.trim(), MAX_BODY_CHARS));
   }
 
   // Safety net: never silently drop a structured Lexware body we couldn't summarize.

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,4 +1,4 @@
-import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
+import { InsufficientScopeError, InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { OAuthMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { createHash } from "node:crypto";
@@ -15,6 +15,12 @@ export interface OAuthSettings {
   verifyAudience: boolean;
   allowedEmailDomains: string[];
   userinfoUrl: string;
+  /** Authorization endpoint advertised in AS metadata. Defaults to `${issuer}/oauth2/authorize`. */
+  authorizationEndpoint: string;
+  /** Token endpoint advertised in AS metadata. Defaults to `${issuer}/oauth2/token`. */
+  tokenEndpoint: string;
+  /** Dynamic client registration endpoint advertised in AS metadata. Defaults to `${issuer}/oauth2/register`. */
+  registrationEndpoint: string;
 }
 
 /** True when `email`'s domain is in `allowed` (case-insensitive). Pure; unit-tested. */
@@ -34,13 +40,14 @@ export function isEmailDomainAllowed(email: string | undefined, allowed: string[
  * (a convenience proxy; modern clients discover the AS via the protected-resource doc).
  */
 export function buildOAuthMetadata(oauth: OAuthSettings): OAuthMetadata {
-  // `issuer` must be exact; endpoints join onto a slash-free base.
-  const base = oauth.issuer.replace(/\/+$/, "");
+  // `issuer` must be exact. The endpoints default to the WorkOS-AuthKit layout but
+  // are overridable (config), so non-WorkOS issuers (Auth0 uses /authorize and
+  // /oauth/token, Keycloak uses /protocol/openid-connect/*) advertise correctly.
   return {
     issuer: oauth.issuer,
-    authorization_endpoint: `${base}/oauth2/authorize`,
-    token_endpoint: `${base}/oauth2/token`,
-    registration_endpoint: `${base}/oauth2/register`,
+    authorization_endpoint: oauth.authorizationEndpoint,
+    token_endpoint: oauth.tokenEndpoint,
+    registration_endpoint: oauth.registrationEndpoint,
     jwks_uri: oauth.jwksUrl,
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
@@ -158,7 +165,10 @@ export function createAccessTokenVerifier(oauth: OAuthSettings, deps: VerifierDe
         }
       }
       if (!isEmailDomainAllowed(email, oauth.allowedEmailDomains)) {
-        throw new InvalidTokenError("Your email domain is not permitted to use this server");
+        // 403, not 401: the token is valid, the user is simply not authorized. A 401
+        // (InvalidTokenError) would make clients discard the token and re-authenticate
+        // in a loop; InsufficientScopeError maps to 403 and terminates cleanly.
+        throw new InsufficientScopeError("Your email domain is not permitted to use this server");
       }
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,44 @@
-import type { Request, Response } from "express";
+import express, { type Request, type Response } from "express";
 import { mcpAuthMetadataRouter, McpServer, requireBearerAuth } from "skybridge/server";
 import { bearerAuthMiddleware } from "./auth.js";
 import { ConfigError, describeCapabilities, loadConfig } from "./config.js";
 import { LexwareClient } from "./lexware/client.js";
 import { buildOAuthMetadata, createAccessTokenVerifier } from "./oauth.js";
 import { registerTools } from "./tools/index.js";
+
+/** Base64 file uploads (upload-file / upload-voucher-file) travel inline in the JSON-RPC body. */
+const JSON_BODY_LIMIT = "12mb";
+const isMcpPath = (p: string): boolean => p === "/mcp" || p.startsWith("/mcp/");
+
+/**
+ * Reconfigure body parsing so large uploads work WITHOUT widening the pre-auth
+ * attack surface. Skybridge pre-applies a single global `express.json()` (~100 KB
+ * default) at router-stack index 0 — before the /mcp auth middleware. We swap that
+ * layer's handler, in place, so it keeps the ~100 KB limit for non-/mcp routes (e.g.
+ * /status) but DEFERS /mcp bodies to a {@link JSON_BODY_LIMIT} parser mounted AFTER
+ * the auth gate (see below). Net effect: an unauthenticated request can never trigger
+ * a multi-MB parse, and authenticated uploads still get the raised limit.
+ *
+ * In-place handler swap (no stack reordering) so it can't mis-order routes. Guarded:
+ * returns false if the internal layer can't be located, and the caller warns loudly.
+ */
+function deferMcpBodyParsing(app: express.Express): boolean {
+  try {
+    type Layer = { handle?: express.RequestHandler & { name?: string } };
+    const router =
+      (app as unknown as { router?: { stack: Layer[] }; _router?: { stack: Layer[] } }).router ??
+      (app as unknown as { _router?: { stack: Layer[] } })._router;
+    const stack = router?.stack;
+    if (!Array.isArray(stack)) return false;
+    const layer = stack.find((l) => l?.handle?.name === "jsonParser");
+    if (!layer) return false;
+    const smallJson = express.json(); // ~100 KB default — for /status and other non-/mcp routes
+    layer.handle = (req, res, next) => (isMcpPath(req.path) ? next() : smallJson(req, res, next));
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 // Fail fast with a clear, secret-free message on any misconfiguration.
 let config;
@@ -36,10 +70,14 @@ const client = new LexwareClient({
 const server = new McpServer(
   {
     name: "lexware-office",
-    version: "0.1.3",
+    version: "0.1.6",
   },
   { capabilities: {} },
 );
+
+// Defer /mcp bodies from the pre-applied ~100 KB global parser (they get the raised
+// limit post-auth, below); other routes keep the small limit.
+const bodyParsingConfigured = deferMcpBodyParsing(server.express);
 
 // Unauthenticated health check. Use `/status`, not `/healthz`: Google Front End
 // intercepts `/healthz` on Cloud Run (it never reaches the container).
@@ -73,13 +111,38 @@ if (config.auth.mode === "oauth") {
 }
 // mode "none": no gate (operator explicitly opted into unauthenticated).
 
+// Parse /mcp bodies at the raised limit — mounted AFTER the auth gate above, so an
+// unauthenticated request is rejected before any multi-MB body is buffered/parsed.
+// (Only effective when the global parser was successfully told to defer /mcp.)
+if (bodyParsingConfigured) {
+  server.use("/mcp", express.json({ limit: JSON_BODY_LIMIT }));
+}
+
 registerTools(server, client, config);
 
-console.error(`[lexware-mcp] starting — ${describeCapabilities(config)}`);
+console.error(
+  `[lexware-mcp] starting — ${describeCapabilities(config)} bodyLimit=${bodyParsingConfigured ? `${JSON_BODY_LIMIT} (/mcp, post-auth)` : "default(~100kb)"}`,
+);
+for (const warning of config.warnings) {
+  console.error(`[lexware-mcp] WARNING: ${warning}`);
+}
+if (!bodyParsingConfigured) {
+  console.error(
+    "[lexware-mcp] WARNING: could not raise the JSON body limit (Skybridge/Express internals changed) — " +
+      "uploads over ~100 KB will be rejected. upload-file/upload-voucher-file may fail until this is fixed.",
+  );
+}
 if (config.auth.mode === "oauth" && config.auth.allowedEmailDomains.length === 0) {
   console.error(
     "[lexware-mcp] WARNING: OAuth mode with no OAUTH_ALLOWED_EMAIL_DOMAINS — ANY user who can " +
       "authenticate with your issuer can reach this server. Set OAUTH_ALLOWED_EMAIL_DOMAINS to restrict access.",
+  );
+}
+if (config.auth.mode === "none") {
+  console.error(
+    "[lexware-mcp] WARNING: /mcp is UNAUTHENTICATED (MCP_ALLOW_UNAUTHENTICATED=true). Anyone who can reach " +
+      "this port can use every enabled tool. Bind to localhost / a private network only, and prefer a browser " +
+      "that blocks DNS-rebinding; configure OAUTH_ISSUER or MCP_AUTH_TOKEN for any shared or public deployment.",
   );
 }
 

--- a/src/tools/articles.ts
+++ b/src/tools/articles.ts
@@ -3,13 +3,15 @@ import { z } from "zod";
 import type { LexwareClient } from "../lexware/client.js";
 import type { Paged } from "../lexware/types.js";
 import {
+  additionalFieldsParam,
   articleInputShape,
   articleUpdateShape,
+  mergeBody,
   pageParam,
   sizeParam,
   versionParam,
 } from "./schemas.js";
-import { DESTRUCTIVE, RO, WRITE, deepMergePatch, pagedResult, text } from "./shared.js";
+import { DESTRUCTIVE, RO, WRITE, deepMergePatch, deleteIdempotent, pagedResult, text } from "./shared.js";
 
 /** Read tools for articles (products/services). Always registered. */
 export function registerArticleReadTools(server: McpServer, client: LexwareClient): void {
@@ -62,11 +64,11 @@ export function registerArticleWriteTools(server: McpServer, client: LexwareClie
     {
       name: "create-article",
       description: "Create a new article (product or service).",
-      inputSchema: articleInputShape,
+      inputSchema: { ...articleInputShape, additionalFields: additionalFieldsParam },
       annotations: WRITE,
     },
-    async (input) => {
-      const created = await client.post<{ id: string }>("/v1/articles", input);
+    async ({ additionalFields, ...input }) => {
+      const created = await client.post<{ id: string }>("/v1/articles", mergeBody(input, additionalFields));
       return { structuredContent: created, content: text(`Created article ${created.id}.`) };
     },
   );
@@ -113,17 +115,17 @@ export function registerArticleDeleteTools(server: McpServer, client: LexwareCli
   server.registerTool(
     {
       name: "delete-article",
-      description: "Delete an article (product/service) by id. This is irreversible.",
+      description:
+        "Delete an article (product/service) by id. This is irreversible. Idempotent: deleting an id that is " +
+        "already absent reports success (the end state is the same).",
       inputSchema: { id: z.string() },
       annotations: DESTRUCTIVE,
     },
     async ({ id }) => {
-      await client.request<unknown>("DELETE", `/v1/articles/${encodeURIComponent(id)}`, {
-        idempotent: true,
-      });
+      const { alreadyAbsent } = await deleteIdempotent(client, `/v1/articles/${encodeURIComponent(id)}`);
       return {
-        structuredContent: { id, deleted: true },
-        content: text(`Deleted article ${id}.`),
+        structuredContent: { id, deleted: true, alreadyAbsent },
+        content: text(alreadyAbsent ? `Article ${id} was already absent (nothing to delete).` : `Deleted article ${id}.`),
       };
     },
   );

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -3,10 +3,12 @@ import { z } from "zod";
 import type { LexwareClient } from "../lexware/client.js";
 import type { Paged } from "../lexware/types.js";
 import {
+  additionalFieldsParam,
   contactInputShape,
   contactUpdateShape,
   jsonBool,
   jsonNum,
+  mergeBody,
   pageParam,
   sizeParam,
   versionParam,
@@ -66,15 +68,18 @@ export function registerContactDraftTools(server: McpServer, client: LexwareClie
       name: "create-contact",
       description:
         "Create a new contact (customer and/or vendor). Provide roles plus either a person (lastName required) or a company (name required).",
-      inputSchema: contactInputShape,
+      inputSchema: { ...contactInputShape, additionalFields: additionalFieldsParam },
       annotations: WRITE,
     },
-    async (input) => {
+    async ({ additionalFields, ...input }) => {
       if (!input.person && !input.company) {
         throw new Error("Provide either a person (with lastName) or a company (with name).");
       }
       // `version` must be 0 when creating.
-      const created = await client.post<{ id: string }>("/v1/contacts", { version: 0, ...input });
+      const created = await client.post<{ id: string }>("/v1/contacts", {
+        version: 0,
+        ...mergeBody(input, additionalFields),
+      });
       return { structuredContent: created, content: text(`Created contact ${created.id}.`) };
     },
   );

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -1,19 +1,21 @@
 import type { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
-import { embeddedResource, type McpServer } from "skybridge/server";
+import type { McpServer } from "skybridge/server";
 import { z } from "zod";
 import type { LexwareClient } from "../lexware/client.js";
 import { type Paged, VOUCHER_STATUSES, VOUCHER_TYPES, type VoucherlistEntry } from "../lexware/types.js";
 import {
+  additionalFieldsParam,
   genericDocumentInputShape,
   invoiceInputShape,
   jsonBool,
   jsonNum,
   jsonObj,
+  mergeBody,
   pageParam,
   quotationInputShape,
   sizeParam,
 } from "./schemas.js";
-import { LOCAL_RO, RO, WRITE, pagedResult, text } from "./shared.js";
+import { LOCAL_RO, RO, WRITE, binaryResult, pagedResult, text } from "./shared.js";
 
 /** A Lexware voucher-document type and how to create it. */
 interface DocType {
@@ -27,23 +29,17 @@ interface DocType {
   schema: ZodRawShapeCompat | null;
   /** Whether `?finalize=true` issuing is supported. */
   finalize: boolean;
-  /**
-   * Whether `GET /v1/{path}/{id}/document` renders a downloadable PDF for this
-   * type. Confirmed in the docs for invoice/quotation/credit-note/delivery-note;
-   * the others are left false until a read-only live check confirms support.
-   */
-  renderable: boolean;
 }
 
 const DOC_TYPES: DocType[] = [
-  { key: "invoice", path: "invoices", label: "invoice", schema: invoiceInputShape, finalize: true, renderable: true },
-  { key: "quotation", path: "quotations", label: "quotation", schema: quotationInputShape, finalize: true, renderable: true },
-  { key: "credit-note", path: "credit-notes", label: "credit note", schema: genericDocumentInputShape, finalize: true, renderable: true },
-  { key: "order-confirmation", path: "order-confirmations", label: "order confirmation", schema: genericDocumentInputShape, finalize: true, renderable: true },
-  { key: "delivery-note", path: "delivery-notes", label: "delivery note", schema: genericDocumentInputShape, finalize: true, renderable: true },
-  { key: "dunning", path: "dunnings", label: "dunning", schema: genericDocumentInputShape, finalize: true, renderable: true },
+  { key: "invoice", path: "invoices", label: "invoice", schema: invoiceInputShape, finalize: true },
+  { key: "quotation", path: "quotations", label: "quotation", schema: quotationInputShape, finalize: true },
+  { key: "credit-note", path: "credit-notes", label: "credit note", schema: genericDocumentInputShape, finalize: true },
+  { key: "order-confirmation", path: "order-confirmations", label: "order confirmation", schema: genericDocumentInputShape, finalize: true },
+  { key: "delivery-note", path: "delivery-notes", label: "delivery note", schema: genericDocumentInputShape, finalize: true },
+  { key: "dunning", path: "dunnings", label: "dunning", schema: genericDocumentInputShape, finalize: true },
   // down-payment-invoices are GET-only (no create/finalize) but still have a finalized PDF via /{id}/file.
-  { key: "down-payment-invoice", path: "down-payment-invoices", label: "down payment invoice", schema: null, finalize: false, renderable: true },
+  { key: "down-payment-invoice", path: "down-payment-invoices", label: "down payment invoice", schema: null, finalize: false },
 ];
 
 /** Document resource paths — the `resourceType` enum for get-document-file. */
@@ -85,6 +81,7 @@ const VOUCHERTYPE_TO_PATH: Record<string, string> = {
   salesinvoice: "vouchers",
   salescreditnote: "vouchers",
   voucher: "vouchers",
+  recurringtemplate: "recurring-templates",
 };
 
 /** Dimensions `summarize-vouchers` can group totals by. */
@@ -191,6 +188,7 @@ export function registerDocumentReadTools(
       let scanned = 0;
       let totalElements = 0;
       let page = 0;
+      let pagesScanned = 0;
       let truncated = false;
       // Walk every page; we only keep aggregates, so the response size is bounded
       // regardless of how many vouchers match.
@@ -206,6 +204,7 @@ export function registerDocumentReadTools(
           size: SIZE,
         });
         totalElements = res.totalElements;
+        pagesScanned++;
         for (const row of res.content) {
           scanned++;
           const key = summaryGroupKey(row, groupBy);
@@ -259,7 +258,7 @@ export function registerDocumentReadTools(
           },
           scanned,
           totalElements,
-          pagesScanned: page + 1,
+          pagesScanned,
           truncated,
           grandTotal: { sumTotalAmount: grandTotal, sumOpenAmount: grandOpen, currency },
           groups: groupList,
@@ -290,7 +289,6 @@ export function registerDocumentReadTools(
 
   // render-<doctype>-pdf: download a document's finalized PDF.
   for (const doc of DOC_TYPES) {
-    if (!doc.renderable) continue;
     server.registerTool(
       {
         name: `render-${doc.key}-pdf`,
@@ -304,17 +302,13 @@ export function registerDocumentReadTools(
         const { data, contentType } = await client.getBinary(
           `/v1/${doc.path}/${encodeURIComponent(id)}/file`,
         );
-        return {
+        return binaryResult({
+          uri: `lexware://${doc.path}/${id}/file`,
+          data,
+          contentType,
           structuredContent: { resource: doc.path, id, mimeType: contentType, byteLength: data.length },
-          content: [
-            ...text(`Downloaded ${doc.label} ${id} PDF (${data.length} bytes).`),
-            embeddedResource({
-              uri: `lexware://${doc.path}/${id}/file`,
-              mimeType: contentType,
-              blob: data.toString("base64"),
-            }),
-          ],
-        };
+          message: `Downloaded ${doc.label} ${id} PDF (${data.length} bytes).`,
+        });
       },
     );
   }
@@ -407,17 +401,13 @@ export function registerDocumentReadTools(
       const { data, contentType } = await client.getBinary(
         `/v1/${resourceType}/${encodeURIComponent(id)}/file`,
       );
-      return {
+      return binaryResult({
+        uri: `lexware://${resourceType}/${id}/file`,
+        data,
+        contentType,
         structuredContent: { resource: resourceType, id, mimeType: contentType, byteLength: data.length },
-        content: [
-          ...text(`Downloaded ${resourceType} ${id} PDF (${data.length} bytes).`),
-          embeddedResource({
-            uri: `lexware://${resourceType}/${id}/file`,
-            mimeType: contentType,
-            blob: data.toString("base64"),
-          }),
-        ],
-      };
+        message: `Downloaded ${resourceType} ${id} PDF (${data.length} bytes).`,
+      });
     },
   );
 
@@ -441,17 +431,13 @@ export function registerDocumentReadTools(
         throw new Error(`Voucher ${id} has no attached file at index ${fileIndex}.`);
       }
       const { data, contentType } = await client.getBinary(`/v1/files/${encodeURIComponent(fileId)}`);
-      return {
+      return binaryResult({
+        uri: `lexware://files/${fileId}`,
+        data,
+        contentType,
         structuredContent: { voucherId: id, fileId, mimeType: contentType, byteLength: data.length },
-        content: [
-          ...text(`Downloaded voucher ${id} receipt (${data.length} bytes, ${contentType}).`),
-          embeddedResource({
-            uri: `lexware://files/${fileId}`,
-            mimeType: contentType,
-            blob: data.toString("base64"),
-          }),
-        ],
-      };
+        message: `Downloaded voucher ${id} receipt (${data.length} bytes, ${contentType}).`,
+      });
     },
   );
 
@@ -489,22 +475,17 @@ function optionalShape(shape: ZodRawShapeCompat): ZodRawShapeCompat {
 }
 
 /** Draft-creation tools for every writable document type. Registered with the drafts tier. */
-export function registerDocumentDraftTools(
-  server: McpServer,
-  client: LexwareClient,
-  finalizeEnabled: boolean,
-): void {
+export function registerDocumentDraftTools(server: McpServer, client: LexwareClient): void {
   for (const doc of DOC_TYPES) {
     if (!doc.schema) continue;
     server.registerTool(
       {
         name: `create-draft-${doc.key}`,
         description:
-          `Create a ${doc.label}. By default a DRAFT (editable, not legally issued). Set finalize=true ` +
-          `(+ confirm_finalize; requires LEXWARE_ENABLE_FINALIZE) to issue a LEGALLY BINDING document in one ` +
-          `step — IRREVERSIBLE (no void/delete via API). Provide the full document body for a standalone ` +
-          `document; with precedingSalesVoucherId the body (line items/contact) is carried over from that ` +
-          `preceding voucher — dunnings can ONLY be created this way (pursue from an invoice).`,
+          `Create a DRAFT ${doc.label} (editable, not legally issued). Provide the full document body for a ` +
+          `standalone document; with precedingSalesVoucherId the body (line items/contact) is carried over ` +
+          `from that preceding voucher — dunnings can ONLY be created this way (pursue from an invoice). ` +
+          `To ISSUE a legally-binding document, use create-finalized-${doc.key} instead (finalize tier).`,
         inputSchema: {
           ...optionalShape(doc.schema),
           precedingSalesVoucherId: z
@@ -514,40 +495,33 @@ export function registerDocumentDraftTools(
               "Create as a follow-up of this preceding sales voucher id (e.g. quotation→order-confirmation→" +
                 "invoice, invoice→credit-note/dunning). POSTs ?precedingSalesVoucherId={id}.",
             ),
+          // Accepted only to fail LOUDLY: finalizing moved to create-finalized-* (finalize
+          // tier). Without these params the SDK would silently strip a stale finalize=true
+          // and create a draft while the caller believed it issued a binding document.
           finalize: jsonBool(z.boolean().optional()).describe(
-            "Issue a legally-binding FINALIZED document (POST ?finalize=true) instead of a draft. IRREVERSIBLE; " +
-              "requires LEXWARE_ENABLE_FINALIZE and confirm_finalize=true.",
+            `MOVED — create-draft-${doc.key} no longer finalizes. Use create-finalized-${doc.key} (finalize tier) to issue a legally-binding document.`,
           ),
-          confirm_finalize: z.literal(true).optional().describe("Must be true when finalize=true."),
+          confirm_finalize: jsonBool(z.boolean().optional()).describe(
+            `MOVED — see create-finalized-${doc.key}.`,
+          ),
+          additionalFields: additionalFieldsParam,
         },
         annotations: WRITE,
       },
-      async ({ finalize, confirm_finalize, precedingSalesVoucherId, ...input }) => {
+      async ({ precedingSalesVoucherId, additionalFields, finalize, confirm_finalize, ...input }) => {
+        if (finalize || confirm_finalize !== undefined) {
+          throw new Error(
+            `create-draft-${doc.key} does not finalize (that moved to a separate tool). To issue a ` +
+              `legally-binding ${doc.label}, use create-finalized-${doc.key} — requires LEXWARE_ENABLE_FINALIZE.`,
+          );
+        }
         const query: Record<string, string | boolean> = {};
         if (precedingSalesVoucherId) query.precedingSalesVoucherId = precedingSalesVoucherId;
-        let finalized = false;
-        if (finalize) {
-          if (!finalizeEnabled) {
-            throw new Error(
-              "Finalizing is disabled. Set LEXWARE_ENABLE_FINALIZE=true to issue a legally-binding document.",
-            );
-          }
-          if (confirm_finalize !== true) {
-            throw new Error(
-              "Set confirm_finalize=true to acknowledge this issues a legally binding, irreversible document.",
-            );
-          }
-          query.finalize = true;
-          finalized = true;
-        }
-        const created = await client.post<{ id: string }>(`/v1/${doc.path}`, input, query);
+        const body = mergeBody(input, additionalFields);
+        const created = await client.post<{ id: string }>(`/v1/${doc.path}`, body, query);
         return {
-          structuredContent: { ...created, finalized },
-          content: text(
-            finalized
-              ? `FINALIZED ${doc.label} ${created.id} (legally binding). This cannot be undone.`
-              : `Created DRAFT ${doc.label} ${created.id} (not finalized).`,
-          ),
+          structuredContent: { ...created, finalized: false },
+          content: text(`Created DRAFT ${doc.label} ${created.id} (not finalized).`),
         };
       },
     );
@@ -576,16 +550,18 @@ export function registerDocumentFinalizeTools(server: McpServer, client: Lexware
             .string()
             .optional()
             .describe("Create as a follow-up of this preceding sales voucher id."),
-          confirm_finalize: z
-            .literal(true)
-            .describe("Must be true to acknowledge this issues a legally binding document."),
+          confirm_finalize: jsonBool(z.literal(true)).describe(
+            "Must be true to acknowledge this issues a legally binding document.",
+          ),
+          additionalFields: additionalFieldsParam,
         },
         annotations: WRITE,
       },
-      async ({ confirm_finalize: _confirm, precedingSalesVoucherId, ...input }) => {
+      async ({ confirm_finalize: _confirm, precedingSalesVoucherId, additionalFields, ...input }) => {
         const query: Record<string, string | boolean> = { finalize: true };
         if (precedingSalesVoucherId) query.precedingSalesVoucherId = precedingSalesVoucherId;
-        const created = await client.post<{ id: string }>(`/v1/${doc.path}`, input, query);
+        const body = mergeBody(input, additionalFields);
+        const created = await client.post<{ id: string }>(`/v1/${doc.path}`, body, query);
         return {
           structuredContent: { ...created, finalized: true },
           content: text(`FINALIZED ${doc.label} ${created.id} (legally binding). This cannot be undone.`),

--- a/src/tools/event-subscriptions.ts
+++ b/src/tools/event-subscriptions.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "skybridge/server";
 import { z } from "zod";
 import type { LexwareClient } from "../lexware/client.js";
-import { DESTRUCTIVE, RO, text, WRITE } from "./shared.js";
+import { DESTRUCTIVE, RO, text, WRITE, deleteIdempotent } from "./shared.js";
 
 /** Read tools for event subscriptions (webhooks). Always registered. */
 export function registerEventSubscriptionReadTools(server: McpServer, client: LexwareClient): void {
@@ -31,16 +31,28 @@ export function registerEventSubscriptionReadTools(server: McpServer, client: Le
   );
 }
 
-/** Non-destructive write tools for event subscriptions. Registered with the drafts tier. */
+/**
+ * Write tools for event subscriptions (webhooks). Registered with the FINALIZE tier
+ * (off by default): a webhook streams financial events to an arbitrary external URL,
+ * so creating one is a data-exfiltration-capable operation and deleting one severs a
+ * possibly third-party integration. Both are gated behind an explicit opt-in and kept
+ * symmetric (whoever can create can delete). See registerTools in ./index.ts.
+ */
 export function registerEventSubscriptionWriteTools(server: McpServer, client: LexwareClient): void {
   server.registerTool(
     {
       name: "create-event-subscription",
       description:
-        "Subscribe a callback URL to a Lexware event type (webhook), e.g. eventType 'invoice.created'. The callback URL must serve a Grade-A HTTPS certificate.",
+        "Subscribe a callback URL to a Lexware event type (webhook), e.g. eventType 'invoice.created'. Sends future " +
+        "event notifications to an EXTERNAL URL, so treat the target as trusted. The callback URL must be https:// " +
+        "and serve a Grade-A HTTPS certificate.",
       inputSchema: {
         eventType: z.string().describe("e.g. 'invoice.created', 'invoice.status.changed'."),
-        callbackUrl: z.string().url().describe("HTTPS endpoint that will receive events."),
+        callbackUrl: z
+          .string()
+          .url()
+          .refine((u) => u.startsWith("https://"), { message: "callbackUrl must be https://." })
+          .describe("HTTPS endpoint that will receive events (Lexware requires a Grade-A HTTPS certificate)."),
       },
       annotations: WRITE,
     },
@@ -59,22 +71,31 @@ export function registerEventSubscriptionWriteTools(server: McpServer, client: L
 }
 
 /**
- * Destructive delete for event subscriptions. Registered with the finalize tier
- * (off by default) so an irreversible delete is never enabled by drafts alone.
+ * Delete (unsubscribe) an event subscription. Registered with the FINALIZE tier,
+ * symmetric with create-event-subscription (both are gated together): it can sever a
+ * webhook belonging to any integration on the org, so it stays behind the explicit
+ * opt-in rather than being available by default.
  */
 export function registerEventSubscriptionDeleteTools(server: McpServer, client: LexwareClient): void {
   server.registerTool(
     {
       name: "delete-event-subscription",
-      description: "Delete (unsubscribe) an event subscription by id. This is irreversible.",
+      description: "Delete (unsubscribe) an event subscription by id. Stops the webhook; recreate it to re-subscribe.",
       inputSchema: { id: z.string() },
       annotations: DESTRUCTIVE,
     },
     async ({ id }) => {
-      await client.request<unknown>("DELETE", `/v1/event-subscriptions/${encodeURIComponent(id)}`, { idempotent: true });
+      const { alreadyAbsent } = await deleteIdempotent(
+        client,
+        `/v1/event-subscriptions/${encodeURIComponent(id)}`,
+      );
       return {
-        structuredContent: { id, deleted: true },
-        content: text(`Deleted event subscription ${id}.`),
+        structuredContent: { id, deleted: true, alreadyAbsent },
+        content: text(
+          alreadyAbsent
+            ? `Event subscription ${id} was already absent (nothing to delete).`
+            : `Deleted event subscription ${id}.`,
+        ),
       };
     },
   );

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -1,7 +1,7 @@
-import { embeddedResource, type McpServer } from "skybridge/server";
+import type { McpServer } from "skybridge/server";
 import { z } from "zod";
 import type { LexwareClient } from "../lexware/client.js";
-import { RO, WRITE, text } from "./shared.js";
+import { RO, WRITE, binaryResult, decodeBase64Strict, text } from "./shared.js";
 
 /** Read tools for the file store. Always registered. */
 export function registerFileReadTools(server: McpServer, client: LexwareClient): void {
@@ -25,17 +25,13 @@ export function registerFileReadTools(server: McpServer, client: LexwareClient):
         `/v1/files/${encodeURIComponent(id)}`,
         accept ?? "*/*",
       );
-      return {
+      return binaryResult({
+        uri: `lexware://files/${id}`,
+        data,
+        contentType,
         structuredContent: { fileId: id, mimeType: contentType, byteLength: data.length },
-        content: [
-          ...text(`Downloaded file ${id} (${data.length} bytes, ${contentType}).`),
-          embeddedResource({
-            uri: `lexware://files/${id}`,
-            mimeType: contentType,
-            blob: data.toString("base64"),
-          }),
-        ],
-      };
+        message: `Downloaded file ${id} (${data.length} bytes, ${contentType}).`,
+      });
     },
   );
 }
@@ -47,8 +43,8 @@ export function registerFileWriteTools(server: McpServer, client: LexwareClient)
       name: "upload-file",
       description:
         "Upload a file to Lexware's file store — the first step of attaching a receipt to a bookkeeping " +
-        "voucher. Provide the file as base64; returns the new file id to reference elsewhere. Keep files " +
-        "small (a few MB): the base64 travels inline in the request.",
+        "voucher. Provide the file as base64; returns the new file id to reference elsewhere. The base64 travels " +
+        "inline in the request (~12 MB body cap), so keep the source file under ~8 MB.",
       inputSchema: {
         fileBase64: z.string().describe("File contents, base64-encoded."),
         filename: z.string().describe('e.g. "receipt-2024-01.pdf".'),
@@ -62,7 +58,7 @@ export function registerFileWriteTools(server: McpServer, client: LexwareClient)
       annotations: WRITE,
     },
     async ({ fileBase64, filename, mimeType, type }) => {
-      const bytes = Buffer.from(fileBase64, "base64");
+      const bytes = decodeBase64Strict(fileBase64, "fileBase64");
       const created = await client.postMultipart<{ id: string }>(
         "/v1/files",
         { bytes, filename, contentType: mimeType },

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -42,16 +42,19 @@ export function registerTools(server: McpServer, client: LexwareClient, config: 
   if (capabilities.drafts) {
     registerContactDraftTools(server, client);
     registerArticleWriteTools(server, client);
-    registerDocumentDraftTools(server, client, capabilities.finalize);
+    registerDocumentDraftTools(server, client);
     registerVoucherWriteTools(server, client);
     registerFileWriteTools(server, client);
-    registerEventSubscriptionWriteTools(server, client);
   }
 
-  // Finalize / binding & irreversible tier.
+  // Finalize / sensitive & irreversible tier (off by default).
   if (capabilities.finalize) {
     registerDocumentFinalizeTools(server, client);
     registerArticleDeleteTools(server, client);
+    // Event-subscription create + delete are gated here (not drafts): a webhook streams
+    // financial events to an arbitrary external URL (exfiltration-capable) and delete can
+    // sever a third-party integration, so both are opt-in and registered together.
+    registerEventSubscriptionWriteTools(server, client);
     registerEventSubscriptionDeleteTools(server, client);
   }
 }

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -4,10 +4,17 @@ import { DEFAULT_PAGE_SIZE } from "./shared.js";
 /**
  * Shared zod schemas for Lexware write payloads.
  *
- * These are intentionally lenient (`.passthrough()` keeps unknown keys) because
- * the full Lexware document schema is large and version-dependent. We validate
- * the load-bearing required fields and forward the rest untouched, so valid
- * requests aren't blocked by an incomplete model.
+ * These are intentionally lenient (`.passthrough()` keeps unknown keys on nested
+ * objects) because the full Lexware document schema is large and version-dependent.
+ * We validate the load-bearing required fields and forward the rest untouched.
+ *
+ * IMPORTANT: `.passthrough()` only preserves unknown keys INSIDE a typed sub-object.
+ * The MCP SDK compiles each tool's top-level input shape with a strip-mode
+ * `z.object`, so an unknown TOP-LEVEL field (e.g. `xRechnung` on an invoice) would
+ * be silently dropped before the handler runs. Every create tool therefore exposes an
+ * `additionalFields` escape hatch ({@link additionalFieldsParam}), merged into the
+ * request body via {@link mergeBody}, so a valid Lexware field we don't model can
+ * still be sent.
  */
 
 /**
@@ -44,6 +51,49 @@ export const versionParam = (noun: string) =>
   jsonNum(z.number().int().optional()).describe(
     `Current version from ${noun} (optimistic lock). Omit to use the latest.`,
   );
+
+/**
+ * Escape hatch for valid Lexware body fields not modeled by a create tool's shape.
+ * Top-level unknown keys are stripped by the SDK's strip-mode object (see the module
+ * doc), so pass any such fields here (e.g. { xRechnung: {...} }) to have them merged
+ * into the request body. Typed fields on the tool take precedence over these.
+ */
+export const additionalFieldsParam = jsonObj(z.record(z.string(), z.unknown()))
+  .optional()
+  .describe(
+    "Extra Lexware body fields not covered by this tool's parameters (e.g. xRechnung), merged into the " +
+      "request as-is. Use only for valid API fields the tool doesn't already expose.",
+  );
+
+/**
+ * Keys that must never be smuggled into a request body via {@link additionalFieldsParam}:
+ * they are query/control parameters (finalize is a query flag; version/id are managed by
+ * the tool), so accepting them in the body would defeat tier gating or optimistic locking.
+ */
+const RESERVED_BODY_KEYS = new Set([
+  "finalize",
+  "confirm_finalize",
+  "precedingSalesVoucherId",
+  "version",
+  "id",
+]);
+
+/**
+ * Build a create/update request body: the tool's typed `input` merged OVER the
+ * `additionalFields` escape hatch (so typed fields always win), with reserved
+ * control keys stripped from the escape hatch first.
+ */
+export function mergeBody(
+  input: Record<string, unknown>,
+  additionalFields: unknown,
+): Record<string, unknown> {
+  const extra =
+    additionalFields && typeof additionalFields === "object" && !Array.isArray(additionalFields)
+      ? { ...(additionalFields as Record<string, unknown>) }
+      : {};
+  for (const k of RESERVED_BODY_KEYS) delete extra[k];
+  return { ...extra, ...input };
+}
 
 /** Shared paging params for list tools (string-coerced). */
 export const pageParam = jsonNum(z.number().int().min(0).default(0)).describe("0-based page index.");
@@ -290,7 +340,9 @@ export const contactInputShape = {
   addresses: jsonObj(contactAddressesSchema).optional(),
   emailAddresses: jsonObj(contactEmailAddressesSchema).optional(),
   phoneNumbers: jsonObj(contactPhoneNumbersSchema).optional(),
-  archived: jsonBool(z.boolean().optional()).describe("Set true to create the contact archived (rare)."),
+  // NOTE: `archived` is deliberately not exposed — it is READ-ONLY on the Lexware
+  // contacts API (verified against the docs), so setting it here would be silently
+  // ignored. Archiving a contact is a web-app-only action; there is no delete either.
   note: z.string().optional(),
 } as const;
 
@@ -315,10 +367,9 @@ export const contactUpdateShape = {
   addresses: jsonObj(contactAddressesSchema).optional(),
   emailAddresses: jsonObj(contactEmailAddressesSchema).optional(),
   phoneNumbers: jsonObj(contactPhoneNumbersSchema).optional(),
-  archived: jsonBool(z.boolean().optional()).describe(
-    "Set true to archive the contact (hide a duplicate). lexoffice has no contact-merge or delete API, and a " +
-      "contact already referenced by documents may not be archivable.",
-  ),
+  // NOTE: `archived` is READ-ONLY on the Lexware contacts API — a PUT with archived:true
+  // is accepted (version bumps) but silently ignored. Archiving is web-app-only and there
+  // is no contact delete, so the param is not exposed (it would mislead the model).
   note: z.string().optional(),
 } as const;
 

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -1,3 +1,5 @@
+import type { LexwareClient } from "../lexware/client.js";
+import { isNotFound } from "../lexware/errors.js";
 import type { Paged } from "../lexware/types.js";
 
 /** Default page size for list tools. */
@@ -17,12 +19,95 @@ export function text(message: string): [{ type: "text"; text: string }] {
 
 /** Standard result for a paged list tool: the Paged envelope + a one-line summary. */
 export function pagedResult<T>(result: Paged<T>, noun: string) {
+  // An empty result set has totalPages 0; render "page 1/1" rather than the
+  // self-contradictory "page 1/0".
+  const totalPages = Math.max(result.totalPages, 1);
   return {
     structuredContent: result,
     content: text(
-      `Found ${result.totalElements} ${noun}; showing page ${result.number + 1}/${result.totalPages}.`,
+      `Found ${result.totalElements} ${noun}; showing page ${result.number + 1}/${totalPages}.`,
     ),
   };
+}
+
+/**
+ * MCP embedded-resource content block for a binary payload. Inlined (rather than
+ * importing Skybridge's `embeddedResource`) so the tools layer stays independent
+ * of the Skybridge runtime, per AGENTS.md.
+ */
+function embeddedResourceBlock(uri: string, mimeType: string, data: Buffer) {
+  return {
+    type: "resource" as const,
+    resource: { uri, mimeType, blob: data.toString("base64") },
+  };
+}
+
+/**
+ * Standard result for a binary-download tool: structured metadata, a one-line
+ * summary, and the file inline as an embedded resource. Shared by every
+ * PDF/file download tool so the envelope shape can't drift across them.
+ */
+export function binaryResult(opts: {
+  uri: string;
+  data: Buffer;
+  contentType: string;
+  structuredContent: Record<string, unknown>;
+  message: string;
+}) {
+  return {
+    structuredContent: opts.structuredContent,
+    content: [...text(opts.message), embeddedResourceBlock(opts.uri, opts.contentType, opts.data)],
+  };
+}
+
+/**
+ * Decode a base64 string to bytes, rejecting malformed input instead of silently
+ * producing garbage. `Buffer.from(s, "base64")` skips invalid characters, so a
+ * value like a leftover `data:...;base64,` prefix or a truncated payload would
+ * otherwise upload corrupt bytes and report success. Accepts standard and
+ * URL-safe alphabets and tolerates a data-URI prefix / embedded whitespace.
+ */
+export function decodeBase64Strict(input: string, field = "file"): Buffer {
+  let s = input.trim();
+  if (s.startsWith("data:")) {
+    const comma = s.indexOf(",");
+    if (comma >= 0) s = s.slice(comma + 1);
+  }
+  s = s.replace(/\s+/g, "");
+  if (!s) throw new Error(`${field}: base64 content is empty.`);
+  // Validate the alphabet (standard or URL-safe) and length up front — Buffer.from
+  // silently drops invalid characters, so a value like a leftover data-URI prefix or
+  // a truncated payload would otherwise decode to garbage. A charset+length check
+  // rejects that without re-encoding the whole (multi-MB) payload, and unlike a
+  // decode/re-encode round-trip it does not reject non-canonical padding that every
+  // standard decoder accepts. Base64 length is never ≡ 1 (mod 4).
+  const body = s.replace(/=+$/, "");
+  if (!/^[A-Za-z0-9+/_-]*$/.test(body) || body.length % 4 === 1) {
+    throw new Error(
+      `${field}: invalid base64 (non-base64 characters or wrong length). Pass the raw base64 without a data-URI prefix.`,
+    );
+  }
+  return Buffer.from(s.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+}
+
+/**
+ * DELETE a resource idempotently. A 404 — the resource is already gone, e.g. a
+ * retried DELETE whose first attempt already succeeded, or an id that never
+ * existed — is treated as success rather than a false failure. Returns whether the
+ * resource was actually found, so callers can distinguish "deleted it" from
+ * "it was already absent".
+ */
+export async function deleteIdempotent(
+  client: LexwareClient,
+  path: string,
+): Promise<{ deleted: true; alreadyAbsent: boolean }> {
+  try {
+    await client.request<unknown>("DELETE", path, { idempotent: true });
+    return { deleted: true, alreadyAbsent: false };
+  } catch (e) {
+    if (isNotFound(e)) return { deleted: true, alreadyAbsent: true };
+    throw e;
+  }
 }
 
 /** True for a non-null, non-array object. */

--- a/src/tools/vouchers.ts
+++ b/src/tools/vouchers.ts
@@ -1,8 +1,8 @@
 import type { McpServer } from "skybridge/server";
 import { z } from "zod";
 import type { LexwareClient } from "../lexware/client.js";
-import { voucherInputShape, voucherUpdateShape } from "./schemas.js";
-import { WRITE, deepMergePatch, text } from "./shared.js";
+import { additionalFieldsParam, mergeBody, versionParam, voucherInputShape, voucherUpdateShape } from "./schemas.js";
+import { WRITE, decodeBase64Strict, deepMergePatch, text } from "./shared.js";
 
 /** Voucher statuses lexoffice DERIVES from payments — re-sending them on PUT is rejected (invalid_value). */
 const DERIVED_VOUCHER_STATUSES = new Set(["paid", "paidoff", "voided", "transferred", "sepadebit"]);
@@ -19,12 +19,12 @@ export function registerVoucherWriteTools(server: McpServer, client: LexwareClie
       description:
         "Create a bookkeeping voucher (a manually-booked sales/purchase transaction). Returns the new id. " +
         "To attach a receipt afterwards, use upload-voucher-file.",
-      inputSchema: voucherInputShape,
+      inputSchema: { ...voucherInputShape, additionalFields: additionalFieldsParam },
       annotations: WRITE,
     },
-    async (input) => {
+    async ({ additionalFields, ...input }) => {
       // `version` must be 0 when creating (optimistic locking), mirroring contacts.
-      const body: Record<string, unknown> = { version: 0, ...input };
+      const body: Record<string, unknown> = { version: 0, ...mergeBody(input, additionalFields) };
       // A referenced contactId can't coexist with a custom contactName (lexoffice 406).
       if (input.contactId) {
         delete body.contactName;
@@ -51,11 +51,7 @@ export function registerVoucherWriteTools(server: McpServer, client: LexwareClie
         "(omit for latest).",
       inputSchema: {
         id: z.string(),
-        version: z
-          .number()
-          .int()
-          .optional()
-          .describe("Current version from get-voucher (optimistic lock). Omit to use the latest."),
+        version: versionParam("get-voucher"),
         ...voucherUpdateShape,
       },
       annotations: WRITE,
@@ -69,10 +65,17 @@ export function registerVoucherWriteTools(server: McpServer, client: LexwareClie
         version: version ?? (current.version as number),
       });
       // A1: a referenced contactId can't coexist with a custom contactName (lexoffice:
-      // custom_contact_name_for_referenced_contact_not_allowed). Drop the name + collective flag.
+      // custom_contact_name_for_referenced_contact_not_allowed). Whichever the caller
+      // sets wins; the other is dropped from the merged body so they never coexist.
       if (fields.contactId) {
         delete body.contactName;
         body.useCollectiveContact = false;
+      } else if (fields.contactName) {
+        // Switching to a one-off name: drop the contactId carried over from the current
+        // voucher (the schema can't express contactId:null), and book to the collective
+        // contact — lexoffice pairs a custom contactName with useCollectiveContact:true.
+        delete body.contactId;
+        body.useCollectiveContact = true;
       }
       // B1: omit a payment-derived voucherStatus unless the caller set one explicitly, so a
       // paid-but-not-filed voucher stays editable (and an explicit "voided" is still attempted).
@@ -96,8 +99,8 @@ export function registerVoucherWriteTools(server: McpServer, client: LexwareClie
       name: "upload-voucher-file",
       description:
         "Attach a file (receipt/scan) to a bookkeeping voucher via POST /v1/vouchers/{id}/files. Provide the " +
-        "file as base64 (inline; keep it under a few MB). To RE-LINK an already-uploaded file by id without " +
-        "re-sending bytes, set the voucher's `files` array via update-voucher instead.",
+        "file as base64 (inline; ~12 MB body cap, so keep the source under ~8 MB). To RE-LINK an already-uploaded " +
+        "file by id without re-sending bytes, set the voucher's `files` array via update-voucher instead.",
       inputSchema: {
         id: z.string().describe("The voucher id to attach the file to."),
         fileBase64: z.string().describe("File contents, base64-encoded."),
@@ -107,7 +110,7 @@ export function registerVoucherWriteTools(server: McpServer, client: LexwareClie
       annotations: WRITE,
     },
     async ({ id, fileBase64, filename, mimeType }) => {
-      const bytes = Buffer.from(fileBase64, "base64");
+      const bytes = decodeBase64Strict(fileBase64, "fileBase64");
       const result = await client.postMultipart<Record<string, unknown>>(
         `/v1/vouchers/${encodeURIComponent(id)}/files`,
         { bytes, filename, contentType: mimeType },

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -9,10 +9,11 @@ function run(authHeader?: string) {
   const req = { headers: authHeader ? { authorization: authHeader } : {} } as Request;
   const json = vi.fn();
   const status = vi.fn(() => ({ json }) as unknown as Response);
-  const res = { status } as unknown as Response;
+  const set = vi.fn();
+  const res = { status, set } as unknown as Response;
   const next = vi.fn() as unknown as NextFunction;
   mw(req, res, next);
-  return { status, json, next };
+  return { status, json, set, next };
 }
 
 describe("bearerAuthMiddleware", () => {
@@ -38,5 +39,10 @@ describe("bearerAuthMiddleware", () => {
     const { status, next } = run(`Bearer ${TOKEN}`);
     expect(status).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("sets a WWW-Authenticate challenge on a 401 (RFC 9110)", () => {
+    const { set } = run("Bearer wrong");
+    expect(set).toHaveBeenCalledWith("WWW-Authenticate", expect.stringContaining("Bearer"));
   });
 });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -17,7 +17,7 @@ function binary(bytes: Uint8Array, status = 200, headers: Record<string, string>
 }
 
 /** Client with rate limiting effectively disabled and deterministic backoff. */
-function makeClient(fetchFn: typeof fetch, slept: number[] = []) {
+function makeClient(fetchFn: typeof fetch, slept: number[] = [], now?: () => number) {
   return new LexwareClient({
     baseUrl: "https://api.test",
     apiKey: "secret-key",
@@ -26,9 +26,29 @@ function makeClient(fetchFn: typeof fetch, slept: number[] = []) {
       slept.push(ms);
     },
     random: () => 0,
+    now,
     rateLimit: { capacity: 1000, refillPerSec: 1000 },
     maxRetries: 4,
   });
+}
+
+/** A 200 Response whose body read rejects, to exercise the body-stream error path. */
+function bodyReadFails(read: "text" | "arrayBuffer"): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: new Headers({ "content-type": "application/json" }),
+    body: null,
+    text: async () => {
+      if (read === "text") throw new TypeError("terminated");
+      return "";
+    },
+    arrayBuffer: async () => {
+      if (read === "arrayBuffer") throw new TypeError("terminated");
+      return new ArrayBuffer(0);
+    },
+  } as unknown as Response;
 }
 
 describe("LexwareClient", () => {
@@ -199,6 +219,40 @@ describe("LexwareClient", () => {
     const { data } = await client.getBinary("/v1/files/x");
     expect([...data]).toEqual([9]);
     expect(n).toBe(2);
+  });
+
+  it("maps a body-read failure on request() to a classified network error (not a raw stream error)", async () => {
+    const fetchFn = vi.fn(async () => bodyReadFails("text")) as unknown as typeof fetch;
+    const client = makeClient(fetchFn);
+    const err = await client.get("/v1/profile").catch((e) => e);
+    expect(err).toBeInstanceOf(LexwareApiError);
+    expect(err.status).toBe(0);
+    expect(err.kind).toBe("network");
+    expect(err.message).toContain("reading Lexware response");
+  });
+
+  it("maps a body-read failure on getBinary to a classified network error", async () => {
+    const fetchFn = vi.fn(async () => bodyReadFails("arrayBuffer")) as unknown as typeof fetch;
+    const client = makeClient(fetchFn);
+    const err = await client.getBinary("/v1/files/x").catch((e) => e);
+    expect(err).toBeInstanceOf(LexwareApiError);
+    expect(err.status).toBe(0);
+    expect(err.kind).toBe("network");
+  });
+
+  it("computes an HTTP-date Retry-After against the injected clock, not wall time", async () => {
+    const slept: number[] = [];
+    const nowMs = 1_000_000_000_000;
+    const retryAt = new Date(nowMs + 5000).toUTCString(); // 5s in the future per the injected clock
+    let n = 0;
+    const fetchFn = vi.fn(async () => {
+      n += 1;
+      return n === 1 ? json({}, 429, { "retry-after": retryAt }) : json({ ok: true });
+    }) as unknown as typeof fetch;
+    const client = makeClient(fetchFn, slept, () => nowMs);
+    await client.get("/v1/profile");
+    // ~5000ms (clamped into [250, 30000]); would be a wild value if wall-clock Date.now() were used.
+    expect(slept.some((ms) => ms >= 4000 && ms <= 6000)).toBe(true);
   });
 
   it("getBinary maps a 406 to a validation error", async () => {

--- a/tests/coercion.test.ts
+++ b/tests/coercion.test.ts
@@ -82,19 +82,13 @@ describe("JSON-string coercion (jsonObj) for object/array params", () => {
   });
 
   it("coerces boolean and number scalar params from strings", () => {
-    const c = parse({ id: z.string(), ...contactUpdateShape }, {
-      id: "c1",
-      archived: "true",
-    }) as Record<string, unknown>;
-    expect(c.archived).toBe(true);
-
     const v = parse(voucherInputShape, {
       type: "purchaseinvoice",
       voucherDate: "2026-06-12T00:00:00.000+02:00",
       useCollectiveContact: "false",
       totalGrossAmount: "11.9",
     }) as Record<string, unknown>;
-    expect(v.useCollectiveContact).toBe(false);
-    expect(v.totalGrossAmount).toBe(11.9);
+    expect(v.useCollectiveContact).toBe(false); // jsonBool coercion
+    expect(v.totalGrossAmount).toBe(11.9); // jsonNum coercion
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -47,6 +47,25 @@ describe("loadConfig", () => {
       resource: "https://mcp.example.com",
       verifyAudience: true,
       allowedEmailDomains: ["example.com", "example.org"],
+      authorizationEndpoint: "https://auth.example.com/oauth2/authorize",
+      tokenEndpoint: "https://auth.example.com/oauth2/token",
+      registrationEndpoint: "https://auth.example.com/oauth2/register",
+    });
+  });
+
+  it("allows overriding the OAuth endpoints for non-WorkOS IdPs (e.g. Auth0)", () => {
+    const c = loadConfig({
+      LEXWARE_API_KEY: "k",
+      OAUTH_ISSUER: "https://tenant.auth0.com/",
+      SERVER_URL: "https://mcp.example.com",
+      OAUTH_AUTHORIZATION_ENDPOINT: "https://tenant.auth0.com/authorize",
+      OAUTH_TOKEN_ENDPOINT: "https://tenant.auth0.com/oauth/token",
+    } as NodeJS.ProcessEnv);
+    expect(c.auth).toMatchObject({
+      authorizationEndpoint: "https://tenant.auth0.com/authorize",
+      tokenEndpoint: "https://tenant.auth0.com/oauth/token",
+      // registration endpoint keeps the derived default when not overridden
+      registrationEndpoint: "https://tenant.auth0.com/oauth2/register",
     });
   });
 
@@ -97,6 +116,21 @@ describe("loadConfig", () => {
   it("can disable drafts", () => {
     const c = loadConfig({ ...base(), LEXWARE_ENABLE_DRAFTS: "false" } as NodeJS.ProcessEnv);
     expect(c.capabilities.drafts).toBe(false);
+  });
+
+  it("finalize force-enables drafts and records a warning when drafts was explicitly off", () => {
+    const c = loadConfig({
+      ...base(),
+      LEXWARE_ENABLE_DRAFTS: "false",
+      LEXWARE_ENABLE_FINALIZE: "true",
+    } as NodeJS.ProcessEnv);
+    expect(c.capabilities).toMatchObject({ drafts: true, finalize: true });
+    expect(c.warnings.join(" ")).toMatch(/overridden to true because LEXWARE_ENABLE_FINALIZE/);
+  });
+
+  it("records no override warning when drafts is left at its default", () => {
+    const c = loadConfig({ ...base(), LEXWARE_ENABLE_FINALIZE: "true" } as NodeJS.ProcessEnv);
+    expect(c.warnings).toEqual([]);
   });
 
   it("rejects an invalid PORT", () => {

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { describeErrorBody, isNotFound, LexwareApiError } from "../src/lexware/errors.js";
+
+describe("describeErrorBody", () => {
+  it("renders an IssueList entry's source + reason", () => {
+    const body = {
+      IssueList: [{ source: "voucherItems[0].taxRatePercent", i18nKey: "invalid_value", type: "validation_failure" }],
+    };
+    const msg = describeErrorBody(406, "Not Acceptable", body);
+    expect(msg).toContain("voucherItems[0].taxRatePercent");
+    expect(msg).toContain("invalid_value");
+  });
+
+  it("truncates a long plain-text body instead of dropping it", () => {
+    const html = `<html>${"x".repeat(5000)}</html>`;
+    const msg = describeErrorBody(502, "Bad Gateway", html);
+    // Old behaviour dropped bodies >= 2000 chars entirely, leaving only the status.
+    expect(msg).not.toBe("Lexware API 502 Bad Gateway");
+    expect(msg).toContain("<html>");
+    expect(msg.endsWith("…")).toBe(true);
+    expect(msg.length).toBeLessThan(2100);
+  });
+
+  it("keeps a short plain-text body verbatim", () => {
+    expect(describeErrorBody(500, "Server Error", "boom")).toBe("Lexware API 500: boom");
+  });
+});
+
+describe("isNotFound", () => {
+  it("is true only for a 404 LexwareApiError", () => {
+    expect(isNotFound(new LexwareApiError(404, "gone"))).toBe(true);
+    expect(isNotFound(new LexwareApiError(409, "conflict"))).toBe(false);
+    expect(isNotFound(new Error("plain"))).toBe(false);
+    expect(isNotFound(undefined)).toBe(false);
+  });
+});

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -18,6 +18,9 @@ function settings(overrides: Partial<OAuthSettings> = {}): OAuthSettings {
     verifyAudience: true,
     allowedEmailDomains: [],
     userinfoUrl: `${ISSUER}/oauth2/userinfo`,
+    authorizationEndpoint: `${ISSUER}/oauth2/authorize`,
+    tokenEndpoint: `${ISSUER}/oauth2/token`,
+    registrationEndpoint: `${ISSUER}/oauth2/register`,
     ...overrides,
   };
 }

--- a/tests/shared.test.ts
+++ b/tests/shared.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it } from "vitest";
-import { deepMergePatch, mergeAddresses } from "../src/tools/shared.js";
+import { describe, expect, it, vi } from "vitest";
+import type { LexwareClient } from "../src/lexware/client.js";
+import { LexwareApiError } from "../src/lexware/errors.js";
+import type { Paged } from "../src/lexware/types.js";
+import {
+  binaryResult,
+  decodeBase64Strict,
+  deepMergePatch,
+  deleteIdempotent,
+  mergeAddresses,
+  pagedResult,
+} from "../src/tools/shared.js";
+import { mergeBody } from "../src/tools/schemas.js";
 
 describe("deepMergePatch (read-modify-write)", () => {
   it("preserves base fields the patch omits", () => {
@@ -68,5 +79,147 @@ describe("mergeAddresses (index-wise contact address merge)", () => {
       { city: "Munich", countryCode: "DE" },
     ]);
     expect(out.shipping).toEqual([{ city: "Hamburg", countryCode: "DE" }]);
+  });
+});
+
+describe("decodeBase64Strict", () => {
+  const b64 = (s: string) => Buffer.from(s, "utf8").toString("base64");
+
+  it("decodes valid standard base64", () => {
+    expect(decodeBase64Strict(b64("hello")).toString("utf8")).toBe("hello");
+  });
+
+  it("strips a data-URI prefix", () => {
+    expect(decodeBase64Strict(`data:application/pdf;base64,${b64("PDF")}`).toString("utf8")).toBe("PDF");
+  });
+
+  it("tolerates embedded whitespace/newlines (wrapped base64)", () => {
+    const wrapped = `${b64("hello world foo bar")}`.replace(/(.{4})/g, "$1\n");
+    expect(decodeBase64Strict(wrapped).toString("utf8")).toBe("hello world foo bar");
+  });
+
+  it("accepts the URL-safe alphabet", () => {
+    const urlSafe = Buffer.from("~~~ ??", "utf8").toString("base64url");
+    expect(decodeBase64Strict(urlSafe).toString("utf8")).toBe("~~~ ??");
+  });
+
+  it("rejects non-base64 characters instead of silently dropping them", () => {
+    // Bare Buffer.from would skip the '!' and '*' and return garbage; we reject.
+    expect(() => decodeBase64Strict("not valid!!! base64 ***")).toThrow(/invalid base64/);
+  });
+
+  it("rejects an empty payload", () => {
+    expect(() => decodeBase64Strict("   ")).toThrow(/empty/);
+  });
+
+  it("accepts non-canonical padding that standard decoders decode identically", () => {
+    // "TR==" and "TQ==" both decode to byte 0x4D; a re-encode round-trip would wrongly
+    // reject "TR==", so the charset+length check must accept it.
+    expect(decodeBase64Strict("TR==")[0]).toBe(0x4d);
+  });
+
+  it("rejects a length that cannot be valid base64 (len % 4 === 1)", () => {
+    expect(() => decodeBase64Strict("QUJD")).not.toThrow(); // 4 chars, valid
+    expect(() => decodeBase64Strict("QUJDR")).toThrow(); // 5 chars → len%4=1, impossible
+  });
+});
+
+describe("mergeBody (create-tool escape hatch)", () => {
+  it("merges additionalFields under the typed input (input wins)", () => {
+    const out = mergeBody({ name: "typed" }, { name: "extra", xRechnung: { ref: "r" } });
+    expect(out).toEqual({ name: "typed", xRechnung: { ref: "r" } });
+  });
+
+  it("strips reserved control keys from additionalFields", () => {
+    const out = mergeBody(
+      { title: "t" },
+      { finalize: true, confirm_finalize: true, precedingSalesVoucherId: "q", version: 5, id: "x", ok: 1 },
+    );
+    expect(out).toEqual({ title: "t", ok: 1 });
+  });
+
+  it("tolerates a missing/non-object additionalFields", () => {
+    expect(mergeBody({ a: 1 }, undefined)).toEqual({ a: 1 });
+    expect(mergeBody({ a: 1 }, "nope")).toEqual({ a: 1 });
+    expect(mergeBody({ a: 1 }, ["x"])).toEqual({ a: 1 });
+  });
+});
+
+describe("deleteIdempotent", () => {
+  it("returns alreadyAbsent=false when the DELETE succeeds", async () => {
+    const request = vi.fn(async () => undefined);
+    const client = { request } as unknown as LexwareClient;
+    await expect(deleteIdempotent(client, "/v1/articles/a1")).resolves.toEqual({
+      deleted: true,
+      alreadyAbsent: false,
+    });
+    expect(request).toHaveBeenCalledWith("DELETE", "/v1/articles/a1", { idempotent: true });
+  });
+
+  it("swallows a 404 and flags alreadyAbsent=true", async () => {
+    const client = {
+      request: vi.fn(async () => {
+        throw new LexwareApiError(404, "not found");
+      }),
+    } as unknown as LexwareClient;
+    await expect(deleteIdempotent(client, "/v1/articles/a1")).resolves.toEqual({
+      deleted: true,
+      alreadyAbsent: true,
+    });
+  });
+
+  it("rethrows a non-404 error", async () => {
+    const client = {
+      request: vi.fn(async () => {
+        throw new LexwareApiError(409, "conflict");
+      }),
+    } as unknown as LexwareClient;
+    await expect(deleteIdempotent(client, "/v1/articles/a1")).rejects.toThrow();
+  });
+});
+
+describe("pagedResult", () => {
+  const paged = (over: Partial<Paged<unknown>>): Paged<unknown> => ({
+    content: [],
+    first: true,
+    last: true,
+    number: 0,
+    numberOfElements: 0,
+    size: 25,
+    totalPages: 0,
+    totalElements: 0,
+    ...over,
+  });
+
+  it("renders page 1/1 (not the impossible 1/0) for an empty result set", () => {
+    const res = pagedResult(paged({}), "contact(s)");
+    expect(res.content[0].text).toBe("Found 0 contact(s); showing page 1/1.");
+  });
+
+  it("renders the real 1-based page/total for a populated set", () => {
+    const res = pagedResult(paged({ number: 1, totalPages: 3, totalElements: 70 }), "article(s)");
+    expect(res.content[0].text).toBe("Found 70 article(s); showing page 2/3.");
+  });
+});
+
+describe("binaryResult", () => {
+  it("builds a text summary + an embedded-resource block with base64 data", () => {
+    const data = Buffer.from("%PDF-1.7");
+    const res = binaryResult({
+      uri: "lexware://files/f1",
+      data,
+      contentType: "application/pdf",
+      structuredContent: { fileId: "f1" },
+      message: "Downloaded file f1.",
+    });
+    expect(res.content[0]).toEqual({ type: "text", text: "Downloaded file f1." });
+    expect(res.content[1]).toEqual({
+      type: "resource",
+      resource: {
+        uri: "lexware://files/f1",
+        mimeType: "application/pdf",
+        blob: data.toString("base64"),
+      },
+    });
   });
 });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -55,7 +55,6 @@ const DRAFT_TOOLS = [
   "create-draft-order-confirmation",
   "create-draft-delivery-note",
   "create-draft-dunning",
-  "create-event-subscription",
   // expansion: bookkeeping vouchers + receipts, file upload
   "create-voucher",
   "update-voucher",
@@ -69,9 +68,12 @@ const FINALIZE_TOOLS = [
   "create-finalized-order-confirmation",
   "create-finalized-delivery-note",
   "create-finalized-dunning",
-  "delete-event-subscription",
   // expansion: destructive article delete (finalize tier)
   "delete-article",
+  // event-subscription create + delete are gated together in the finalize tier: a webhook
+  // to an arbitrary external URL is exfiltration-capable, so it is opt-in, not default-on.
+  "create-event-subscription",
+  "delete-event-subscription",
 ];
 
 /** Capture which tool names get registered for a given config. */
@@ -111,5 +113,14 @@ describe("registerTools (tiered registration)", () => {
   it("never registers a disabled tier's tools", () => {
     const names = registeredNames(loadConfig(env({ LEXWARE_ENABLE_DRAFTS: "false" })));
     expect(names).toEqual([...READ_TOOLS].sort());
+  });
+
+  it("finalize implies drafts: enabling finalize with drafts off still registers drafts", () => {
+    // Guards against a config that exposes ONLY the irreversible create-finalized-*
+    // tools (no safe draft path).
+    const names = registeredNames(
+      loadConfig(env({ LEXWARE_ENABLE_DRAFTS: "false", LEXWARE_ENABLE_FINALIZE: "true" })),
+    );
+    expect(names).toEqual([...READ_TOOLS, ...DRAFT_TOOLS, ...FINALIZE_TOOLS].sort());
   });
 });

--- a/tests/write-tools.test.ts
+++ b/tests/write-tools.test.ts
@@ -2,9 +2,15 @@ import type { McpServer } from "skybridge/server";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import type { LexwareClient } from "../src/lexware/client.js";
-import { registerArticleWriteTools } from "../src/tools/articles.js";
+import { LexwareApiError } from "../src/lexware/errors.js";
+import { registerArticleDeleteTools, registerArticleWriteTools } from "../src/tools/articles.js";
+import { registerEventSubscriptionDeleteTools } from "../src/tools/event-subscriptions.js";
 import { registerContactDraftTools } from "../src/tools/contacts.js";
-import { registerDocumentDraftTools, registerDocumentReadTools } from "../src/tools/documents.js";
+import {
+  registerDocumentDraftTools,
+  registerDocumentFinalizeTools,
+  registerDocumentReadTools,
+} from "../src/tools/documents.js";
 import { invoiceInputShape } from "../src/tools/schemas.js";
 import { registerVoucherWriteTools } from "../src/tools/vouchers.js";
 
@@ -183,9 +189,7 @@ describe("invoice draft: paymentConditions set at creation (the API has no PUT/u
     const post = vi.fn(async () => ({ id: "i1" }));
     const client = { post } as unknown as LexwareClient;
 
-    await handlersFor((s, c) => registerDocumentDraftTools(s, c, true), client)["create-draft-invoice"](
-      sample,
-    );
+    await handlersFor(registerDocumentDraftTools, client)["create-draft-invoice"](sample);
 
     const call = post.mock.calls[0] as [string, Record<string, unknown>, unknown];
     expect(call[0]).toBe("/v1/invoices");
@@ -213,6 +217,27 @@ describe("update-voucher contact + status handling", () => {
     expect(body.contactId).toBe("contact-9");
     expect(body.contactName).toBeUndefined();
     expect(body.useCollectiveContact).toBe(false);
+    expect(body.files).toEqual(["f1"]); // RMW still preserves the receipt
+  });
+
+  it("A2: setting a one-off contactName drops the contactId carried over from the current voucher", async () => {
+    const current = {
+      id: "v1",
+      contactId: "contact-9",
+      voucherStatus: "open",
+      files: ["f1"],
+      version: 1,
+    };
+    const request = vi.fn(async () => ({ id: "v1", version: 2 }));
+    const client = { get: vi.fn(async () => current), request } as unknown as LexwareClient;
+    await handlersFor(registerVoucherWriteTools, client)["update-voucher"]({
+      id: "v1",
+      contactName: "Sammellieferant",
+    });
+    const body = putBody(request);
+    expect(body.contactName).toBe("Sammellieferant");
+    expect(body.contactId).toBeUndefined(); // inherited id cleared so the two don't 406
+    expect(body.useCollectiveContact).toBe(true); // one-off name books to the collective contact
     expect(body.files).toEqual(["f1"]); // RMW still preserves the receipt
   });
 
@@ -261,6 +286,9 @@ describe("get-document dispatch + get-voucher-file", () => {
     expect(get).toHaveBeenCalledWith("/v1/vouchers/x");
     await handlers["get-document"]({ id: "y", voucherType: "quotation" });
     expect(get).toHaveBeenCalledWith("/v1/quotations/y");
+    // recurringtemplate is a real voucherlist type and must dispatch, not throw.
+    await handlers["get-document"]({ id: "r", voucherType: "recurringtemplate" });
+    expect(get).toHaveBeenCalledWith("/v1/recurring-templates/r");
     await expect(handlers["get-document"]({ id: "z", voucherType: "bogus" })).rejects.toThrow(
       /Unknown voucherType/,
     );
@@ -289,48 +317,130 @@ const docBody = {
   shippingConditions: { shippingType: "none" },
 };
 
-describe("create-draft finalize gating + precedingSalesVoucherId", () => {
-  it("creates a draft and passes precedingSalesVoucherId as a query", async () => {
+describe("create-draft: body forwarding + precedingSalesVoucherId (no finalize flag)", () => {
+  it("creates a draft and passes precedingSalesVoucherId as a query; never finalizes", async () => {
     const post = vi.fn(async () => ({ id: "i1" }));
     const client = { post } as unknown as LexwareClient;
-    const handlers = handlersFor((s, c) => registerDocumentDraftTools(s, c, true), client);
-    await handlers["create-draft-invoice"]({ ...docBody, precedingSalesVoucherId: "q9" });
-    const call = post.mock.calls[0] as [string, Record<string, unknown>, Record<string, unknown>];
-    expect(call[0]).toBe("/v1/invoices");
-    expect(call[2]).toEqual({ precedingSalesVoucherId: "q9" });
-    expect(call[1].finalize).toBeUndefined(); // finalize stripped from the body
-  });
-
-  it("finalize:true is rejected when the finalize capability is off", async () => {
-    const post = vi.fn(async () => ({ id: "i1" }));
-    const client = { post } as unknown as LexwareClient;
-    const handlers = handlersFor((s, c) => registerDocumentDraftTools(s, c, false), client);
-    await expect(
-      handlers["create-draft-invoice"]({ ...docBody, finalize: true, confirm_finalize: true }),
-    ).rejects.toThrow(/LEXWARE_ENABLE_FINALIZE/);
-    expect(post).not.toHaveBeenCalled();
-  });
-
-  it("finalize:true requires confirm_finalize even when enabled", async () => {
-    const post = vi.fn(async () => ({ id: "i1" }));
-    const client = { post } as unknown as LexwareClient;
-    const handlers = handlersFor((s, c) => registerDocumentDraftTools(s, c, true), client);
-    await expect(handlers["create-draft-invoice"]({ ...docBody, finalize: true })).rejects.toThrow(
-      /confirm_finalize/,
-    );
-  });
-
-  it("finalize:true + confirm + capability POSTs ?finalize=true", async () => {
-    const post = vi.fn(async () => ({ id: "i1" }));
-    const client = { post } as unknown as LexwareClient;
-    const handlers = handlersFor((s, c) => registerDocumentDraftTools(s, c, true), client);
+    const handlers = handlersFor(registerDocumentDraftTools, client);
     const res = (await handlers["create-draft-invoice"]({
       ...docBody,
-      finalize: true,
+      precedingSalesVoucherId: "q9",
+    })) as { structuredContent: { finalized: boolean } };
+    const call = post.mock.calls[0] as [string, Record<string, unknown>, Record<string, unknown>];
+    expect(call[0]).toBe("/v1/invoices");
+    expect(call[2]).toEqual({ precedingSalesVoucherId: "q9" }); // no finalize in the query
+    expect(res.structuredContent.finalized).toBe(false);
+  });
+
+  it("merges additionalFields into the body (top-level escape hatch for unmodeled fields)", async () => {
+    const post = vi.fn(async () => ({ id: "i1" }));
+    const client = { post } as unknown as LexwareClient;
+    const handlers = handlersFor(registerDocumentDraftTools, client);
+    await handlers["create-draft-invoice"]({
+      ...docBody,
+      additionalFields: { xRechnung: { buyerReference: "04011000-12345-06" } },
+    });
+    const body = (post.mock.calls[0] as [string, Record<string, unknown>, unknown])[1];
+    expect(body.xRechnung).toEqual({ buyerReference: "04011000-12345-06" }); // merged in
+    expect(body.additionalFields).toBeUndefined(); // not forwarded as a literal key
+  });
+
+  it("strips reserved control keys (finalize) smuggled via additionalFields", async () => {
+    const post = vi.fn(async () => ({ id: "i1" }));
+    const client = { post } as unknown as LexwareClient;
+    const handlers = handlersFor(registerDocumentDraftTools, client);
+    await handlers["create-draft-invoice"]({
+      ...docBody,
+      additionalFields: { finalize: true, xRechnung: { buyerReference: "x" } },
+    });
+    const call = post.mock.calls[0] as [string, Record<string, unknown>, Record<string, unknown>];
+    expect(call[1].finalize).toBeUndefined(); // reserved key not smuggled into the body
+    expect(call[1].xRechnung).toEqual({ buyerReference: "x" }); // legitimate extra kept
+    expect(call[2]).toEqual({}); // and never reaches the query either
+  });
+
+  it("rejects a stale finalize=true on a draft tool with a pointer to create-finalized-*", async () => {
+    const post = vi.fn(async () => ({ id: "i1" }));
+    const client = { post } as unknown as LexwareClient;
+    const handlers = handlersFor(registerDocumentDraftTools, client);
+    await expect(
+      handlers["create-draft-invoice"]({ ...docBody, finalize: true, confirm_finalize: true }),
+    ).rejects.toThrow(/create-finalized-invoice/);
+    expect(post).not.toHaveBeenCalled(); // fails loudly instead of silently creating a draft
+  });
+});
+
+describe("create-finalized-* (finalize tier): the only finalize path", () => {
+  it("POSTs ?finalize=true, strips confirm_finalize, and returns finalized:true", async () => {
+    const post = vi.fn(async () => ({ id: "i1" }));
+    const client = { post } as unknown as LexwareClient;
+    const handlers = handlersFor(registerDocumentFinalizeTools, client);
+    const res = (await handlers["create-finalized-invoice"]({
+      ...docBody,
       confirm_finalize: true,
     })) as { structuredContent: { finalized: boolean } };
-    expect((post.mock.calls[0] as [string, unknown, Record<string, unknown>])[2]).toEqual({ finalize: true });
+    const call = post.mock.calls[0] as [string, Record<string, unknown>, Record<string, unknown>];
+    expect(call[0]).toBe("/v1/invoices");
+    expect(call[2]).toEqual({ finalize: true });
+    expect(call[1].confirm_finalize).toBeUndefined(); // confirmation flag never sent to the API
     expect(res.structuredContent.finalized).toBe(true);
+  });
+
+  it("passes precedingSalesVoucherId alongside finalize (pursue → issue in one step)", async () => {
+    const post = vi.fn(async () => ({ id: "i1" }));
+    const client = { post } as unknown as LexwareClient;
+    const handlers = handlersFor(registerDocumentFinalizeTools, client);
+    await handlers["create-finalized-invoice"]({
+      ...docBody,
+      confirm_finalize: true,
+      precedingSalesVoucherId: "q9",
+    });
+    const query = (post.mock.calls[0] as [string, unknown, Record<string, unknown>])[2];
+    expect(query).toEqual({ finalize: true, precedingSalesVoucherId: "q9" });
+  });
+});
+
+describe("delete tools: idempotent (a retried delete that already succeeded returns 404)", () => {
+  it("delete-article reports deleted with alreadyAbsent=false on a real delete", async () => {
+    const request = vi.fn(async () => undefined);
+    const client = { request } as unknown as LexwareClient;
+    const res = (await handlersFor(registerArticleDeleteTools, client)["delete-article"]({
+      id: "a1",
+    })) as { structuredContent: { deleted: boolean; alreadyAbsent: boolean } };
+    expect(res.structuredContent.deleted).toBe(true);
+    expect(res.structuredContent.alreadyAbsent).toBe(false);
+  });
+
+  it("delete-article treats a 404 as already-deleted and flags alreadyAbsent=true", async () => {
+    const request = vi.fn(async () => {
+      throw new LexwareApiError(404, "not found");
+    });
+    const client = { request } as unknown as LexwareClient;
+    const res = (await handlersFor(registerArticleDeleteTools, client)["delete-article"]({
+      id: "a1",
+    })) as { structuredContent: { deleted: boolean; alreadyAbsent: boolean } };
+    expect(res.structuredContent.deleted).toBe(true);
+    expect(res.structuredContent.alreadyAbsent).toBe(true);
+  });
+
+  it("delete-article still throws on a non-404 error", async () => {
+    const request = vi.fn(async () => {
+      throw new LexwareApiError(409, "conflict");
+    });
+    const client = { request } as unknown as LexwareClient;
+    await expect(handlersFor(registerArticleDeleteTools, client)["delete-article"]({ id: "a1" })).rejects.toThrow();
+  });
+
+  it("delete-event-subscription treats a 404 as already-unsubscribed", async () => {
+    const request = vi.fn(async () => {
+      throw new LexwareApiError(404, "not found");
+    });
+    const client = { request } as unknown as LexwareClient;
+    const res = (await handlersFor(registerEventSubscriptionDeleteTools, client)["delete-event-subscription"]({
+      id: "s1",
+    })) as { structuredContent: { deleted: boolean; alreadyAbsent: boolean } };
+    expect(res.structuredContent.deleted).toBe(true);
+    expect(res.structuredContent.alreadyAbsent).toBe(true);
   });
 });
 
@@ -403,6 +513,8 @@ describe("summarize-vouchers (server-side aggregation, no row dump)", () => {
     };
     expect(get).toHaveBeenCalledTimes(1);
     expect(res.structuredContent.truncated).toBe(true);
+    // Exactly one page was fetched, so pagesScanned is 1 (not the old page+1 = 2).
+    expect(res.structuredContent.pagesScanned).toBe(1);
     expect(res.structuredContent.groups[0].key).toBe("all");
   });
 });


### PR DESCRIPTION
A review-driven hardening pass over the tool surface, **verified live** against a real Lexware account and deployed to production (Cloud Run revision `lexware-mcp-00022-dgp`). Full per-version breakdown in `CHANGELOG.md` (0.1.4–0.1.6).

## Correctness
- Error-body read failures are classified as `LexwareApiError` (a 404 stays a 404, so `isNotFound` keeps working).
- `create-draft-*` now **rejects a stale `finalize=true` loudly** instead of silently returning a draft — finalizing lives only in the dedicated `create-finalized-*` tools (finalize tier).
- `update-voucher`: a one-off `contactName` clears the inherited `contactId` and sets `useCollectiveContact=true`; `version` accepts string-coerced numbers like the sibling tools.
- `get-document` dispatches `voucherType: "recurringtemplate"`.
- Base64 uploads validated by charset+length (no full re-encode; no false-reject of non-canonical padding); malformed input is rejected instead of silently corrupting the upload.
- `summarize-vouchers` page-count off-by-one; empty lists render `page 1/1` not `1/0`.
- Delete tools are idempotent (404 → `alreadyAbsent`) and report which case occurred.
- Removed the **read-only, silently-ignored** `archived` param from the contact tools (confirmed read-only in the Lexware docs and live).

## Security / hardening
- The raised 12 MB upload body limit is mounted on `/mcp` **after** auth (other routes keep ~100 KB), so unauthenticated requests can't force a multi-MB parse.
- Webhook `create`/`delete-event-subscription` moved to the **finalize tier (off by default)** — a webhook streams financial events to an external URL.
- `create-event-subscription` requires an `https://` callback URL.
- OAuth-domain denial returns **403** (not a 401 re-auth loop); static `401`s carry a `WWW-Authenticate` challenge; OAuth authorize/token/registration endpoints are overridable for non-WorkOS IdPs (Auth0, Keycloak).

## Robustness / cleanup
- `additionalFields` escape hatch on every create tool (reserved control keys stripped) so valid unmodeled fields (e.g. `xRechnung`) aren't silently dropped by the SDK's strip-mode object.
- Shared `binaryResult` / `deleteIdempotent` / `mergeBody` helpers; the tools layer no longer imports Skybridge at runtime.
- Finalize implies drafts; startup WARNINGs for overridden flags and body-limit fallback.

## Verification
- `npm run build` (typecheck) clean; **134 tests passing**.
- Live-tested via the connector: reads, `get-document` dispatch, `summarize-vouchers`, `get-voucher-file`, the finalize-reject guard, and the `additionalFields`/`mergeBody` round-trip (incl. reserved-key strip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)