### PR TITLE
Expose line-item optional/alternative flags (v0.1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7]
+
+### Added
+- **Line items expose `optional` and `alternative`** on every document create tool (invoice, quotation,
+  credit-note, order-confirmation, delivery-note — shared `lineItemSchema`). `optional` marks an optional
+  position (shown with its price but not counted in the total); `alternative` marks an alternative position.
+  Both are string-coercible and forwarded to the Lexware API. Previously these lexoffice fields weren't
+  modelled, so the model had no way to know it could set them.
+
 ## [0.1.6]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lexware-mcp",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": false,
   "license": "MIT",
   "description": "Open-source, self-hostable MCP server for the Lexware Office API",

--- a/src/server.ts
+++ b/src/server.ts
@@ -70,7 +70,7 @@ const client = new LexwareClient({
 const server = new McpServer(
   {
     name: "lexware-office",
-    version: "0.1.6",
+    version: "0.1.7",
   },
   { capabilities: {} },
 );

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -118,6 +118,12 @@ export const lineItemSchema = z
     quantity: z.number().optional(),
     unitName: z.string().optional().describe('e.g. "piece", "hour".'),
     unitPrice: moneySchema.optional(),
+    optional: jsonBool(z.boolean().optional()).describe(
+      "Optional line item (Optionale Position): shown with its price but NOT counted in the document total.",
+    ),
+    alternative: jsonBool(z.boolean().optional()).describe(
+      "Alternative line item (Alternativposition): an alternative to another position; not counted in the total.",
+    ),
   })
   .passthrough();
 

--- a/tests/coercion.test.ts
+++ b/tests/coercion.test.ts
@@ -91,4 +91,22 @@ describe("JSON-string coercion (jsonObj) for object/array params", () => {
     expect(v.useCollectiveContact).toBe(false); // jsonBool coercion
     expect(v.totalGrossAmount).toBe(11.9); // jsonNum coercion
   });
+
+  it("keeps line-item optional/alternative flags (incl. from strings) so they reach the API", () => {
+    const parsed = parse(invoiceInputShape, {
+      voucherDate: "2026-07-06",
+      address: { contactId: "c1" },
+      totalPrice: { currency: "EUR" },
+      taxConditions: { taxType: "net" },
+      shippingConditions: { shippingType: "service" },
+      lineItems: [
+        { type: "custom", name: "Base", unitPrice: { currency: "EUR", netAmount: 100 } },
+        // second line item is optional; a string-serialising client sends "true"
+        { type: "custom", name: "Add-on", optional: "true", alternative: false, unitPrice: { currency: "EUR", netAmount: 50 } },
+      ],
+    }) as { lineItems: Array<Record<string, unknown>> };
+    expect(parsed.lineItems[0].optional).toBeUndefined(); // omitted → not sent
+    expect(parsed.lineItems[1].optional).toBe(true); // "true" coerced and preserved
+    expect(parsed.lineItems[1].alternative).toBe(false);
+  });
 });


### PR DESCRIPTION
lexoffice line items support two fields the tools didn't model:
- **`optional`** — an optional position, shown with its price but **not counted in the document total**.
- **`alternative`** — an alternative position.

`get-quotation` returns them (`"optional":false,"alternative":false` per item), but the shared `lineItemSchema` didn't expose them, so the model had no way to know it could set them. This adds both as string-coercible booleans on `lineItemSchema` — which is shared across every document create tool (invoice, quotation, credit-note, order-confirmation, delivery-note). The handler already forwards line items wholesale, so no handler change is needed.

Verified: the shared schema keeps `optional`/`alternative` (incl. `"true"` string coercion) so they reach the API; 135 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)